### PR TITLE
Add method-chain syntax for VarToVal expression

### DIFF
--- a/SPO_CS/Regression.Tests/08_01_Var.SPO
+++ b/SPO_CS/Regression.Tests/08_01_Var.SPO
@@ -1,4 +1,4 @@
 §VAR x := 1 .
 x := 2 .
 
-§EXPORT (§TO_VAL x)
+§EXPORT ((x :=>))

--- a/SPO_CS/Regression.Tests/08_02_DefIncrement.SPO
+++ b/SPO_CS/Regression.Tests/08_02_DefIncrement.SPO
@@ -7,7 +7,7 @@
 ) : (
 	§DEF Y € §INT
 ) {
-	X := ((§TO_VAL X) .+ Y).
+	X := ((X :=>) .+ Y).
 }
 
 §VAR X := 1, + 2 .
@@ -17,4 +17,4 @@
 	+ 4
 .
 
-§EXPORT (§TO_VAL X, §TO_VAL Y)
+§EXPORT ((X :=>), (Y :=>))

--- a/SPO_CS/Regression.Tests/_VAR.SPO
+++ b/SPO_CS/Regression.Tests/_VAR.SPO
@@ -4,11 +4,11 @@
 }
 
 §DEF +... = §DEF o € [§VAR §INT] : §DEF i € §INT {
-	o := ((§TO_VAL o) .+ i) .
+	o := ((o :=>) .+ i) .
 }
 
 §DEF *... = §DEF o € [§VAR §INT] : §DEF i € §INT {
-	o := ((§TO_VAL o) .* i) .
+	o := ((o :=>) .* i) .
 }
 
 §VAR x := 1 .

--- a/SPO_CS/src/mSPO2IL.cs
+++ b/SPO_CS/src/mSPO2IL.cs
@@ -858,15 +858,44 @@ mSPO2IL {
 				aDefConstructor.AddLocal(ResultReg, Type.AssertNotEmpty());
 				return ResultReg;
 			}
-			case mSPO_AST.tVarToValNode<tPos> { Pos: var Pos, Obj: var Obj, TypeAnnotation: var Type }: {
-				if (!aDefConstructor.MapExpression(aModuleConstructor, Obj).Match(out var ObjReg, out var Error)) {
-					return mResult.Fail(Error);
-				}
-				var ResultReg = aDefConstructor.CreateTempReg();
-				aDefConstructor.Commands.Push(mIL_AST.VarGet(Pos, ResultReg, ObjReg));
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, Type.AssertNotEmpty());
-				return ResultReg;
-			}
+				case mSPO_AST.tVarToValNode<tPos> { Pos: var Pos, Obj: var Obj, MethodCalls: var MethodCalls, TypeAnnotation: var Type }: {
+					if (!aDefConstructor.MapExpression(aModuleConstructor, Obj).Match(out var ObjReg, out var Error)) {
+						return mResult.Fail(Error);
+					}
+					foreach (var Call in MethodCalls) {
+						if (!aDefConstructor.MapExpression(aModuleConstructor, Call.Argument).Match(out var Arg, out Error)) {
+							return mResult.Fail(Error);
+						}
+						if (Call.Argument.TypeAnnotation.IsSome(out var ArgType) && ArgType.IsVar(out var ArgInnerType)) {
+							var ArgValue = aDefConstructor.CreateTempReg();
+							aDefConstructor.Commands.Push(mIL_AST.VarGet(Call.Argument.Pos, ArgValue, Arg));
+							aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ArgValue, ArgInnerType);
+							Arg = ArgValue;
+						}
+						var MethodId = Call.Method.Id;
+						if (MethodId is "_=...") {
+							aDefConstructor.Commands.Push(mIL_AST.VarSet(Pos, ObjReg, Arg));
+							continue;
+						}
+						var Result = Call.Result.IsNone() ? mIL_AST.cEmptyValue : aDefConstructor.CreateTempReg();
+						var MethodReg = aDefConstructor.CreateTempReg();
+						aDefConstructor.Commands.Push(
+							[
+								mIL_AST.CreatePair(Obj.Pos, MethodReg, ObjReg, MethodId),
+								mIL_AST.CallProc(Pos, Result, MethodReg, Arg)
+							]
+						);
+						if (Call.Result.IsSome(out var ResultMatch)) {
+							if (!aDefConstructor.MapMatch(ResultMatch, Result, out Error)) {
+								return mResult.Fail(Error);
+							}
+						}
+					}
+					var ResultReg = aDefConstructor.CreateTempReg();
+					aDefConstructor.Commands.Push(mIL_AST.VarGet(Pos, ResultReg, ObjReg));
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, Type.AssertNotEmpty());
+					return ResultReg;
+}
 			case mSPO_AST.tRecursiveTypeNode<tPos> { Pos: var Pos, HeadType: var HeadType, BodyType: var BodyType, TypeAnnotation: var Type }: {
 				mAssert.IsFalse(aDefConstructor.EnvIds.ToStream().Any(_ => _ == HeadType.Id));
 				aDefConstructor.Commands.Push(

--- a/SPO_CS/src/mSPO_AST.cs
+++ b/SPO_CS/src/mSPO_AST.cs
@@ -377,6 +377,7 @@ mSPO_AST {
 		public tPos Pos { get; init; }
 		public mMaybe.tMaybe<mVM_Type.tType> TypeAnnotation { get; set; }
 		public tExpressionNode<tPos> Obj = default!;
+		public mStream.tStream<tMethodCallNode<tPos>> MethodCalls = mStd.cEmpty;
 	}
 	
 	[DebuggerDisplay(cDebuggerDisplay)]
@@ -872,14 +873,16 @@ mSPO_AST {
 		MethodCalls = aMethodCalls
 	};
 	
-	public static tVarToValNode<tPos>
-	VarToVal<tPos>(
-		tPos aPos,
-		tExpressionNode<tPos> aObj
-	) => new() {
-		Pos = aPos,
-		Obj = aObj,
-	};
+public static tVarToValNode<tPos>
+VarToVal<tPos>(
+ tPos aPos,
+ tExpressionNode<tPos> aObj,
+ mStream.tStream<tMethodCallNode<tPos>> aMethodCalls
+) => new() {
+Pos = aPos,
+Obj = aObj,
+MethodCalls = aMethodCalls,
+};
 	
 	public static tMethodCallsNode<tPos>
 	MethodCallStatement<tPos>(
@@ -1173,7 +1176,14 @@ mSPO_AST {
 			case tVarToValNode<tPos> Node1: {
 				return (
 					a2 is tVarToValNode<tPos> Node2 &&
-					AreEqual(Node1.Obj, Node2.Obj)
+					AreEqual(Node1.Obj, Node2.Obj) &&
+					mStream.ZipExtend(Node1.MethodCalls, Node2.MethodCalls).All(
+						_ => (
+							_._1.IsSome(out var a1) &&
+							_._2.IsSome(out var a2) &&
+							AreEqual(a1, a2)
+						)
+					)
 				);
 			}
 			case tMethodCallNode<tPos> Node1: {
@@ -1264,7 +1274,11 @@ mSPO_AST {
 			tIntNode<t> Node => "" + Node.Value,
 			tTextNode<t> Node => $"\"{Node.Value}\"",
 			tPrefixNode<t> Node => $"({____}#{Node.Prefix} {Node.Element.ToText(____)}{__})",
-			tVarToValNode<t> Node => $"({____}({__}§VAR_TO_VAL {Node.Obj.ToText(____)}{__})",
+			tVarToValNode<t> Node => Node.MethodCalls.Match(
+				() => $"({____}{Node.Obj.ToText(____)} :=>{__})",
+				(aHead, aTail) =>
+					$"({____}{Node.Obj.ToText(____)} : {mStream.Stream(aHead, aTail).Map(_ => _.ToText(____)).Join((a1, a2) => a1 + ", " + a2, "")}, =>{__})"
+			),
 			tTupleNode<t> Node => $"({Node.Items.Map(_ => ____ + _.ToText(____)).Join((a1, a2) => a1 + ", " + a2, "")}{__})",
 			tLambdaNode<t> Node => $"({____}{Node.Head.ToText(____)} => {Node.Body.ToText(____)}{__})",
 			tCallNode<t> Node => $"({____}.{Node.Func.ToText(____)} {Node.Arg.ToText(____)}{__})",

--- a/SPO_CS/src/mSPO_AST_Types.cs
+++ b/SPO_CS/src/mSPO_AST_Types.cs
@@ -214,13 +214,17 @@ mSPO_AST_Types {
 					() => VarToVal.Obj.UpdateTypes(
 						aScope
 					).ThenTry<mVM_Type.tType, mVM_Type.tType, (tPos Pos, tText ErrorText)>(
-						_ => (
-							_.IsVar(out var ValType)
-							? ValType
-							: mResult.Fail((VarToVal.Pos, $"the type '{_}' in not from type '[§VAR ...]'"))
+						ObjType => VarToVal.MethodCalls.Reduce(
+							mResult.OK(aScope).WithErrorType<(tPos Pos, tText ErrorText)>(),
+							(Scope, MethodCall) => Scope.ThenTry(_ => UpdateMethodCallTypes(MethodCall, _))
+						).ThenTry(
+							_ => (
+								ObjType.IsVar(out var ValType)
+								? ValType
+								: mResult.Fail((VarToVal.Pos, $"the type '{ObjType}' in not from type '[§VAR ..]'"))
+							)
 						)
 					)
-				)
 			),
 			mSPO_AST.tIfNode<tPos> If => (
 				If.Cases.Map(

--- a/SPO_CS/src/mSPO_Lowering.cs
+++ b/SPO_CS/src/mSPO_Lowering.cs
@@ -30,13 +30,34 @@ mSPO_Lowering {
 				Body = (mSPO_AST.tBlockNode<tPos>)aBody
 			).Do(_ => { _.TypeAnnotation = Type; })
 		),
-		mSPO_AST.tVarToValNode<tPos> { Pos: var Pos, Obj: var Obj, TypeAnnotation: var Type }
-		=> LowerExpression(Obj).Then(
-			aObj => (mSPO_AST.tExpressionNode<tPos>)mSPO_AST.VarToVal(
-				Pos,
-				aObj
-			).Do(_ => { _.TypeAnnotation = Type; })
-		),
+		mSPO_AST.tVarToValNode<tPos> { Pos: var Pos, Obj: var Obj, MethodCalls: var MethodCalls, TypeAnnotation: var Type }
+		=> LowerExpression(Obj).ThenTry(
+			aObj => MethodCalls.Map(
+				aCall => LowerExpression(aCall.Argument).Then(
+						aCallArg => mSPO_AST.MethodCall(
+							aCall.Pos,
+							aCall.Method,
+							aCallArg,
+							aCall.Result.Then(
+								aCallResult => mSPO_AST.Match(
+									aCallResult.Pos,
+									aCallResult.Pattern,
+									aCallResult.TypeExpression.Then(
+										aCallResultTypeExpression => LowerExpression(aCallResultTypeExpression).ElseThrow(""))
+								)
+							)
+						)
+				)
+			).WhenAllThen(
+				aCalls => (mSPO_AST.tExpressionNode<tPos>)mSPO_AST.VarToVal(
+					Pos,
+					aObj,
+					aCalls
+				).Do(_ => { _.TypeAnnotation = Type; })
+			)
+		)
+)
+),
 		mSPO_AST.tCallNode<tPos> { Pos: var Pos, Func: var Func, Arg: var Arg, TypeAnnotation: var Type }
 		=> LowerExpression(Func).ThenTry(
 			aFunc => LowerExpression(Arg).Then(

--- a/SPO_CS/src/mSPO_Parser.Tests.cs
+++ b/SPO_CS/src/mSPO_Parser.Tests.cs
@@ -424,7 +424,7 @@ mSPO_Parser_Tests {
 						mSPO_Parser.Command.ParseText(
 							//        1         2         3         4         5        6          7         8
 							//2345678901234567890123456789012345678901234567890123456789012345678901234567890
-							"o := ((§TO_VAL o) .+ i) .\n",
+"o := ((o :=>) .+ i) .\n",
 							"",
 							_ => { aStreamOut(_()); }
 						),
@@ -442,10 +442,11 @@ mSPO_Parser_Tests {
 											mSPO_AST.Tuple(
 												Span((1, 7), (1, 22)), 
 												[
-													mSPO_AST.VarToVal(
-														Span((1, 8), (1, 16)),
-														mSPO_AST.Id(Span((1, 16), (1, 16)), "o")
-													),
+mSPO_AST.VarToVal(
+Span((1, 8), (1, 16)),
+mSPO_AST.Id(Span((1, 16), (1, 16)), "o"),
+mStream.Stream<mSPO_AST.tMethodCallNode<tSpan>>([])
+),
 													mSPO_AST.Id(Span((1, 22), (1, 22)), "i")
 												]
 											)

--- a/SPO_CS/src/mSPO_Parser.cs
+++ b/SPO_CS/src/mSPO_Parser.cs
@@ -584,15 +584,23 @@ mSPO_Parser {
 	)
 	.SetName(nameof(MethodCall));
 	
+public static readonly mParserGen.tParser<tPos, tToken, mStream.tStream<mSPO_AST.tMethodCallNode<tSpan>>, tError>
+MethodCalls = mParserGen.Seq(
+MethodCall,
+((-SpecialToken(",")|-NLs_Token) +MethodCall)[0..],
+NLs_Token[0..1],
+SpecialToken(".")
+)
+.Modify((aFirst, aRest, _, _) => mStream.Stream(aFirst, aRest))
+.SetName(nameof(MethodCalls));
+
 	public static readonly mParserGen.tParser<tPos, tToken, mStream.tStream<mSPO_AST.tMethodCallNode<tSpan>>, tError>
-	MethodCalls = mParserGen.Seq(
+	MethodCallList = mParserGen.Seq(
 		MethodCall,
-		((-SpecialToken(",")|-NLs_Token) +MethodCall)[0..],
-		NLs_Token[0..1],
-		SpecialToken(".")
+		((-SpecialToken(",") | -NLs_Token) +MethodCall)[0..]
 	)
-	.Modify((aFirst, aRest, _, _) => mStream.Stream(aFirst, aRest))
-	.SetName(nameof(MethodCalls));
+	.Modify((aFirst, aRest) => mStream.Stream(aFirst, aRest))
+	.SetName(nameof(MethodCallList));
 	
 	public static readonly mParserGen.tParser<tPos, tToken, mSPO_AST.tDefVarNode<tSpan>, tError>
 	DefVar = mParserGen.Seq(
@@ -610,8 +618,28 @@ mSPO_Parser {
 	.SetName(nameof(DefVar));
 	
 	public static readonly mParserGen.tParser<tPos, tToken, mSPO_AST.tVarToValNode<tSpan>, tError>
-	VarToVal = (-KeyWord("TO_VAL") +Expression)
-	.ModifyS(mSPO_AST.VarToVal)
+	VarToVal = mParserGen.Seq(
+		SpecialToken("("),
+		ExpressionInCall,
+		SpecialToken(":"),
+		NLs_Token[0..1],
+		MethodCallList[0..1],
+		((-SpecialToken(",") | -NLs_Token))[0..],
+		SpecialToken("=>"),
+		NLs_Token[0..1],
+		SpecialToken(")")
+	)
+	.Modify((_, aObj, _, _, aCalls, _, _, _, _) => (aObj, aCalls))
+	.ModifyS(
+		(aSpan, aObj, aMaybeCalls) => mSPO_AST.VarToVal(
+				aSpan,
+				aObj,
+				aMaybeCalls.Match(
+					() => mStream.Stream<mSPO_AST.tMethodCallNode<tSpan>>([]),
+					aCalls => aCalls
+				)
+			)
+	)
 	.SetName(nameof(VarToVal));
 	
 	public static readonly mParserGen.tParser<tPos, tToken, mSPO_AST.tMethodCallsNode<tSpan>, tError>

--- a/SPO_CS/src/mStdLib.Tests.cs
+++ b/SPO_CS/src/mStdLib.Tests.cs
@@ -34,11 +34,11 @@ mStdLib_Tests {
 							}
 							
 							§DEF +... = §DEF o € [§VAR §INT] : §DEF i € §INT {
-								o := ((§TO_VAL o) .+ i) .
+								o := ((o :=>) .+ i) .
 							}
 							
 							§DEF *... = §DEF o € [§VAR §INT] : §DEF i € §INT {
-								o := ((§TO_VAL o) .* i) .
+								o := ((o :=>) .* i) .
 							}
 							
 							§VAR x := 1 .


### PR DESCRIPTION
## Summary
- replace the legacy §TO_VAL expression with the new method-chain `(X := …, =>)` syntax in the parser and fixtures
- extend the AST, lowering, typing, and IL emission to carry method-call chains when converting variables to values
- update parser and stdlib tests plus regression files to exercise the new syntax

## Testing
- not run (dotnet 9.0 tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd7f586d108329827e25c30797ad96