### PR TITLE
Implement method-chain VarToVal syntax

### DIFF
--- a/SPO_CS/Regression.Tests/08_01_Var.SPO
+++ b/SPO_CS/Regression.Tests/08_01_Var.SPO
@@ -1,4 +1,4 @@
 §VAR x := 1 .
 x := 2 .
 
-§EXPORT (§TO_VAL x)
+§EXPORT (x :=>)

--- a/SPO_CS/Regression.Tests/08_02_DefIncrement.SPO
+++ b/SPO_CS/Regression.Tests/08_02_DefIncrement.SPO
@@ -7,7 +7,7 @@
 ) : (
 	§DEF Y € §INT
 ) {
-	X := ((§TO_VAL X) .+ Y).
+	X := ((X :=>) .+ Y).
 }
 
 §VAR X := 1, + 2 .
@@ -17,4 +17,4 @@
 	+ 4
 .
 
-§EXPORT (§TO_VAL X, §TO_VAL Y)
+§EXPORT ((X :=>), (Y :=>))

--- a/SPO_CS/Regression.Tests/_VAR.SPO
+++ b/SPO_CS/Regression.Tests/_VAR.SPO
@@ -4,11 +4,11 @@
 }
 
 §DEF +... = §DEF o € [§VAR §INT] : §DEF i € §INT {
-	o := ((§TO_VAL o) .+ i) .
+	o := ((o :=>) .+ i) .
 }
 
 §DEF *... = §DEF o € [§VAR §INT] : §DEF i € §INT {
-	o := ((§TO_VAL o) .* i) .
+	o := ((o :=>) .* i) .
 }
 
 §VAR x := 1 .

--- a/SPO_CS/src/mSPO2IL.cs
+++ b/SPO_CS/src/mSPO2IL.cs
@@ -858,16 +858,48 @@ mSPO2IL {
 				aDefConstructor.AddLocal(ResultReg, Type.AssertNotEmpty());
 				return ResultReg;
 			}
-			case mSPO_AST.tVarToValNode<tPos> { Pos: var Pos, Obj: var Obj, TypeAnnotation: var Type }: {
-				if (!aDefConstructor.MapExpression(aModuleConstructor, Obj).Match(out var ObjReg, out var Error)) {
+			case mSPO_AST.tVarToValNode<tPos> { Pos: var Pos, Obj: var Obj, MethodCalls: var MethodCalls, TypeAnnotation: var Type }: {
+				if (!aDefConstructor.MapExpression(aModuleConstructor, Obj).Match(out var CurrentReg, out var Error)) {
 					return mResult.Fail(Error);
 				}
-				var ResultReg = aDefConstructor.CreateTempReg();
-				aDefConstructor.Commands.Push(mIL_AST.VarGet(Pos, ResultReg, ObjReg));
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, Type.AssertNotEmpty());
-				return ResultReg;
+				foreach (var MethodCall in MethodCalls) {
+					if (!aDefConstructor.MapExpression(aModuleConstructor, MethodCall.Argument).Match(out var ArgReg, out Error)) {
+						return mResult.Fail(Error);
+					}
+					if (MethodCall.Argument.TypeAnnotation.IsSome(out var ArgType) && ArgType.IsVar(out var ArgInnerType)) {
+						var ArgValue = aDefConstructor.CreateTempReg();
+						aDefConstructor.Commands.Push(mIL_AST.VarGet(MethodCall.Argument.Pos, ArgValue, ArgReg));
+						aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ArgValue, ArgInnerType);
+						ArgReg = ArgValue;
+					}
+					var MethodId = MethodCall.Method.Id;
+					if (MethodId is "_=...") {
+						aDefConstructor.Commands.Push(mIL_AST.VarSet(MethodCall.Pos, CurrentReg, ArgReg));
+						continue;
+					}
+					var MethodReg = aDefConstructor.CreateTempReg();
+					var ResultReg = aDefConstructor.CreateTempReg();
+					aDefConstructor.Commands.Push(
+						mIL_AST.CreatePair(Obj.Pos, MethodReg, CurrentReg, MethodId),
+						mIL_AST.CallProc(MethodCall.Pos, ResultReg, MethodReg, ArgReg)
+					);
+					var MethodType = MethodCall.Method.TypeAnnotation.AssertNotEmpty();
+					if (MethodType.IsProc(out var _, out var _, out var MethResType)) {
+						aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, MethResType);
+					}
+					if (MethodCall.Result.IsSome(out var ResultMatch)) {
+						if (!aDefConstructor.MapMatch(ResultMatch, ResultReg, out var MatchError)) {
+							return mResult.Fail(MatchError);
+						}
+					}
+					CurrentReg = ResultReg;
+				}
+				var ValueReg = aDefConstructor.CreateTempReg();
+				aDefConstructor.Commands.Push(mIL_AST.VarGet(Pos, ValueReg, CurrentReg));
+				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ValueReg, Type.AssertNotEmpty());
+				return ValueReg;
 			}
-			case mSPO_AST.tRecursiveTypeNode<tPos> { Pos: var Pos, HeadType: var HeadType, BodyType: var BodyType, TypeAnnotation: var Type }: {
+                       case mSPO_AST.tRecursiveTypeNode<tPos> { Pos: var Pos, HeadType: var HeadType, BodyType: var BodyType, TypeAnnotation: var Type }: {
 				mAssert.IsFalse(aDefConstructor.EnvIds.ToStream().Any(_ => _ == HeadType.Id));
 				aDefConstructor.Commands.Push(
 					mIL_AST.TypeFree(HeadType.Pos, HeadType.Id)

--- a/SPO_CS/src/mSPO_AST_Types.cs
+++ b/SPO_CS/src/mSPO_AST_Types.cs
@@ -209,19 +209,31 @@ mSPO_AST_Types {
 					)
 				)
 			),
-			mSPO_AST.tVarToValNode<tPos> VarToVal => (
-				mStd.Call(
-					() => VarToVal.Obj.UpdateTypes(
-						aScope
-					).ThenTry<mVM_Type.tType, mVM_Type.tType, (tPos Pos, tText ErrorText)>(
-						_ => (
-							_.IsVar(out var ValType)
-							? ValType
-							: mResult.Fail((VarToVal.Pos, $"the type '{_}' in not from type '[§VAR ...]'"))
-						)
-					)
-				)
-			),
+                        mSPO_AST.tVarToValNode<tPos> VarToVal => (
+                                VarToVal.Obj.UpdateTypes(
+                                        aScope
+                                ).ThenTry(
+                                        aObjType => VarToVal.MethodCalls.Reduce(
+                                                mResult.OK((Scope: aScope, ObjType: aObjType)).WithErrorType<(tPos Pos, tText ErrorText)>(),
+                                                (State, MethodCall) => State.ThenTry(
+                                                        aState => UpdateMethodCallTypes(MethodCall, aState.Scope).ThenTry(
+                                                                aScopeAfter => {
+                                                                        var MethodType = MethodCall.Method.TypeAnnotation.AssertNotEmpty();
+                                                                        return MethodType.IsProc(out var _, out var _, out var MethResType)
+                                                                                ? mResult.OK((Scope: aScopeAfter, ObjType: MethResType)).WithErrorType<(tPos Pos, tText ErrorText)>()
+                                                                                : mResult.Fail((MethodCall.Pos, $"'{MethodType.ToText()}' is not a Proc"));
+                                                                }
+                                                        )
+                                                )
+                                        ).ThenTry(
+                                                aState => (
+                                                        aState.ObjType.IsVar(out var ValType)
+                                                        ? mResult.OK(ValType).WithErrorType<(tPos Pos, tText ErrorText)>()
+                                                        : mResult.Fail((VarToVal.Pos, $"the type '{aState.ObjType.ToText()}' in not from type '[§VAR ..]'"))
+                                                )
+                                        )
+                                )
+                        ),
 			mSPO_AST.tIfNode<tPos> If => (
 				If.Cases.Map(
 					aCase => aCase.Cond.UpdateTypes(

--- a/SPO_CS/src/mSPO_Lowering.cs
+++ b/SPO_CS/src/mSPO_Lowering.cs
@@ -30,12 +30,32 @@ mSPO_Lowering {
 				Body = (mSPO_AST.tBlockNode<tPos>)aBody
 			).Do(_ => { _.TypeAnnotation = Type; })
 		),
-		mSPO_AST.tVarToValNode<tPos> { Pos: var Pos, Obj: var Obj, TypeAnnotation: var Type }
-		=> LowerExpression(Obj).Then(
-			aObj => (mSPO_AST.tExpressionNode<tPos>)mSPO_AST.VarToVal(
-				Pos,
-				aObj
-			).Do(_ => { _.TypeAnnotation = Type; })
+		mSPO_AST.tVarToValNode<tPos> { Pos: var Pos, Obj: var Obj, MethodCalls: var Calls, TypeAnnotation: var Type }
+		=> LowerExpression(Obj).ThenTry(
+				aObj => Calls.Map(
+					aCall => LowerExpression(aCall.Argument).Then(
+						aCallArg => mSPO_AST.MethodCall(
+							aCall.Pos,
+							aCall.Method,
+							aCallArg,
+							aCall.Result.Then(
+								aCallResult => mSPO_AST.Match(
+									aCallResult.Pos,
+									aCallResult.Pattern,
+									aCallResult.TypeExpression.Then(
+										aCallResultTypeExpression => LowerExpression(aCallResultTypeExpression).ElseThrow("") // TODO: remove ElseThrow()
+									)
+								)
+							)
+						)
+					)
+				).WhenAllThen(
+					aCalls => (mSPO_AST.tExpressionNode<tPos>)mSPO_AST.VarToVal(
+						Pos,
+						aObj,
+						aCalls
+				).Do(_ => { _.TypeAnnotation = Type; })
+				)
 		),
 		mSPO_AST.tCallNode<tPos> { Pos: var Pos, Func: var Func, Arg: var Arg, TypeAnnotation: var Type }
 		=> LowerExpression(Func).ThenTry(

--- a/SPO_CS/src/mSPO_Parser.Tests.cs
+++ b/SPO_CS/src/mSPO_Parser.Tests.cs
@@ -324,7 +324,7 @@ mSPO_Parser_Tests {
 												mStd.cEmpty
 											),
 											mSPO_AST.Match(
-												Span((1, 8), (1, 16)),
+												Span((1, 7), (1, 13)),
 												mSPO_AST.MatchTuple(
 													Span((1, 8), (1, 16)),
 													mStream.Stream(
@@ -424,7 +424,7 @@ mSPO_Parser_Tests {
 						mSPO_Parser.Command.ParseText(
 							//        1         2         3         4         5        6          7         8
 							//2345678901234567890123456789012345678901234567890123456789012345678901234567890
-							"o := ((§TO_VAL o) .+ i) .\n",
+							"o := ((o :=>) .+ i) .\n",
 							"",
 							_ => { aStreamOut(_()); }
 						),
@@ -442,9 +442,10 @@ mSPO_Parser_Tests {
 											mSPO_AST.Tuple(
 												Span((1, 7), (1, 22)), 
 												[
-													mSPO_AST.VarToVal(
-														Span((1, 8), (1, 16)),
-														mSPO_AST.Id(Span((1, 16), (1, 16)), "o")
+                                                                                                    mSPO_AST.VarToVal(
+                                                                                                            Span((1, 7), (1, 13)),
+                                                                                                            mSPO_AST.Id(Span((1, 8), (1, 8)), "o"),
+                                                                                                            mStream.Stream<mSPO_AST.tMethodCallNode<tSpan>>([])
 													),
 													mSPO_AST.Id(Span((1, 22), (1, 22)), "i")
 												]

--- a/SPO_CS/src/mSPO_Parser.cs
+++ b/SPO_CS/src/mSPO_Parser.cs
@@ -609,10 +609,31 @@ mSPO_Parser {
 	.ModifyS(mSPO_AST.DefVar)
 	.SetName(nameof(DefVar));
 	
-	public static readonly mParserGen.tParser<tPos, tToken, mSPO_AST.tVarToValNode<tSpan>, tError>
-	VarToVal = (-KeyWord("TO_VAL") +Expression)
-	.ModifyS(mSPO_AST.VarToVal)
-	.SetName(nameof(VarToVal));
+        public static readonly mParserGen.tParser<tPos, tToken, mStream.tStream<mSPO_AST.tMethodCallNode<tSpan>>, tError>
+        MethodCallsInVarToVal = mParserGen.Seq(
+        	MethodCall,
+        	((-SpecialToken(",") | -NLs_Token) +MethodCall)[0..],
+        	(-SpecialToken(",") | -NLs_Token)[0..]
+        )
+        .Modify((aFirst, aRest, _) => mStream.Stream(aFirst, aRest))
+        .SetName(nameof(MethodCallsInVarToVal));
+
+        public static readonly mParserGen.tParser<tPos, tToken, mSPO_AST.tVarToValNode<tSpan>, tError>
+        VarToVal = mParserGen.Seq(
+        	SpecialToken("("),
+        	ExpressionInCall,
+        	SpecialToken(":"),
+        	NLs_Token[0..1],
+        	MethodCallsInVarToVal[0..1]
+        	.Modify(aCalls => aCalls.TryFirst().ElseUse(mStream.Stream<mSPO_AST.tMethodCallNode<tSpan>>([]))),
+        	SpecialToken("=>"),
+        	NLs_Token[0..1],
+        	SpecialToken(")")
+        )
+        .Modify((_, aObj, _, _, aCalls, _, _, _) => (aObj, aCalls))
+        .ModifyS(mSPO_AST.VarToVal)
+        .SetName(nameof(VarToVal));
+
 	
 	public static readonly mParserGen.tParser<tPos, tToken, mSPO_AST.tMethodCallsNode<tSpan>, tError>
 	MethodCallStatement = mParserGen.Seq(

--- a/SPO_CS/src/mStdLib.Tests.cs
+++ b/SPO_CS/src/mStdLib.Tests.cs
@@ -34,11 +34,11 @@ mStdLib_Tests {
 							}
 							
 							§DEF +... = §DEF o € [§VAR §INT] : §DEF i € §INT {
-								o := ((§TO_VAL o) .+ i) .
+								o := ((o :=>) .+ i) .
 							}
 							
 							§DEF *... = §DEF o € [§VAR §INT] : §DEF i € §INT {
-								o := ((§TO_VAL o) .* i) .
+								o := ((o :=>) .* i) .
 							}
 							
 							§VAR x := 1 .


### PR DESCRIPTION
## Summary
- replace the legacy §TO_VAL expression with the new `(Obj : ... =>)` parser production
- extend lowering, type checking, and IL generation so VarToVal can execute method chains before extracting the final value
- update regression inputs and parser/stdlib tests to use the new syntax

## Testing
- not run (missing required .NET runtime in container)

------
https://chatgpt.com/codex/tasks/task_e_68cd7f586d108329827e25c30797ad96