### PR TITLE
Add §IS expression support

### DIFF
--- a/SPO_CS/src/mSPO_AST.cs
+++ b/SPO_CS/src/mSPO_AST.cs
@@ -285,6 +285,15 @@ mSPO_AST {
 	
 	[DebuggerDisplay(cDebuggerDisplay)]
 	public sealed record
+	tIsNode<tPos> : tExpressionNode<tPos> {
+		public tPos Pos { get; init; }
+		public mMaybe.tMaybe<mVM_Type.tType> TypeAnnotation { get; set; }
+		public tExpressionNode<tPos> Value = default!;
+		public tMatchNode<tPos> Pattern = default!;
+	}
+	
+	[DebuggerDisplay(cDebuggerDisplay)]
+	public sealed record
 	tPrefixTypeNode<tPos> : tTypeNode<tPos> {
 		public tPos Pos { get; init; }
 		public mMaybe.tMaybe<mVM_Type.tType> TypeAnnotation { get; set; }
@@ -859,6 +868,17 @@ mSPO_AST {
 		Cases = aCases
 	};
 	
+	public static tIsNode<tPos>
+	Is<tPos>(
+		tPos aPos,
+		tExpressionNode<tPos> aValue,
+		tMatchNode<tPos> aPattern
+	) => new() {
+		Pos = aPos,
+		Value = aValue,
+		Pattern = aPattern
+	};
+	
 	public static tDefVarNode<tPos>
 	DefVar<tPos>(
 		tPos aPos,
@@ -1146,6 +1166,13 @@ mSPO_AST {
 			case tIfMatchNode<tPos>: {
 				break;
 			}
+			case tIsNode<tPos> Node1: {
+				return (
+					 a2 is tIsNode<tPos> Node2 &&
+					 AreEqual(Node1.Value, Node2.Value) &&
+					 AreEqual(Node1.Pattern, Node2.Pattern)
+				);
+			}
 			case tPrefixTypeNode<tPos>: {
 				break;
 			}
@@ -1277,6 +1304,7 @@ mSPO_AST {
 					(a1, a2) => a1 + "; " + a2
 				)
 			),
+			tIsNode<t> Node => $"({____}{Node.Value.ToText(____)} §IS {Node.Pattern.ToText(____)}{__})",
 			tPipeToLeftNode<t> Node => $"({____} {Node.Pipe.Map(_ => $"{_.ToText()} §<")}{Node.Head.ToText()}{__})",
 			
 			// Matches

--- a/SPO_CS/src/mSPO_AST_Types.Tests.cs
+++ b/SPO_CS/src/mSPO_AST_Types.Tests.cs
@@ -55,6 +55,22 @@ mSPO_AST_Types_Tests {
 					);
 				}
 			),
+			mTest.Test("Is",
+				aDebugStream => {
+					mAssert.AreEquals(
+						mSPO_AST.Is(
+							cNoPos,
+							mSPO_AST.Int(cNoPos, 1),
+							mSPO_AST.Match(
+								cNoPos,
+								mSPO_AST.Int(cNoPos, 1),
+								mStd.cEmpty
+							)
+						).UpdateTypes(mStd.cEmpty),
+						mVM_Type.Bool()
+					);
+				}
+			),
 			mTest.Test("Lambda",
 				aDebugStream => {
 					mAssert.AreEquals(

--- a/SPO_CS/src/mSPO_AST_Types.cs
+++ b/SPO_CS/src/mSPO_AST_Types.cs
@@ -209,6 +209,16 @@ mSPO_AST_Types {
 					)
 				)
 			),
+			mSPO_AST.tIsNode<tPos> Is => (
+				Is.Value.UpdateTypes(aScope).ThenTry(
+					aValueType => UpdateMatchTypes(
+						Is.Pattern,
+						aValueType,
+						tTypeRelation.Super,
+						aScope
+					).Then(_ => mVM_Type.Bool())
+				)
+			),
 			mSPO_AST.tVarToValNode<tPos> VarToVal => (
 				VarToVal.Obj.UpdateTypes(
 					aScope

--- a/SPO_CS/src/mSPO_Lowering.cs
+++ b/SPO_CS/src/mSPO_Lowering.cs
@@ -100,6 +100,17 @@ mSPO_Lowering {
 				).Do(_ => { _.TypeAnnotation = Type; })
 			)
 		),
+		mSPO_AST.tIsNode<tPos> { Pos: var Pos, Value: var Value, Pattern: var Pattern, TypeAnnotation: var Type }
+		=> LowerExpression(Value).Then(
+			aValue => (mSPO_AST.tExpressionNode<tPos>)mSPO_AST.IfMatch(
+				Pos,
+				aValue,
+				mStream.Stream(new (mSPO_AST.tMatchNode<tPos>, mSPO_AST.tExpressionNode<tPos>)[] {
+					(Pattern, (mSPO_AST.tExpressionNode<tPos>)mSPO_AST.True(Pos)),
+					(mSPO_AST.Match(Pos, mSPO_AST.IgnoreMatch(Pos), mStd.cEmpty), (mSPO_AST.tExpressionNode<tPos>)mSPO_AST.False(Pos))
+				})
+			).Do(_ => { _.TypeAnnotation = Type; })
+		),
 		mSPO_AST.tPipeToRightNode<tPos> Pipe
 		=> mStd.Call(
 			() => {

--- a/SPO_CS/src/mSPO_Parser.Tests.cs
+++ b/SPO_CS/src/mSPO_Parser.Tests.cs
@@ -137,7 +137,28 @@ mSPO_Parser_Tests {
 					);
 				}
 			),
-			mTest.Test("FunctionCall",
+			mTest.Test("Is",
+				aStreamOut => {
+				mAssert.AreEquals(
+					mSPO_Parser.Expression.ParseText(
+						"(x §IS 12)",
+						"",
+						_ => { aStreamOut(_()); }
+					),
+				mSPO_AST.Is(
+					Span((1, 1), (1, 10)),
+					mSPO_AST.Id(Span((1, 2), (1, 2)), "x"),
+					mSPO_AST.Match(
+						Span((1, 8), (1, 9)),
+						mSPO_AST.Int(Span((1, 8), (1, 9)), 12),
+						mStd.cEmpty
+					)
+				),
+				mSPO_AST.AreEqual
+			);
+		}
+	),
+	mTest.Test("FunctionCall",
 				aStreamOut => {
 					mAssert.AreEquals(
 						mSPO_Parser.Expression.ParseText(

--- a/SPO_CS/src/mSPO_Parser.cs
+++ b/SPO_CS/src/mSPO_Parser.cs
@@ -567,6 +567,15 @@ mSPO_Parser {
 	.Modify((_, aExpression, _, aBranches, _) => (aExpression, aBranches))
 	.ModifyS(mSPO_AST.IfMatch)
 	.SetName(nameof(IfMatch));
+	public static readonly mParserGen.tParser<tPos, tToken, mSPO_AST.tIsNode<tSpan>, tError>
+	Is = mParserGen.Seq(
+		ExpressionInCall,
+		KeyWord("IS"),
+		Match
+	)
+	.Modify((aValue, _, aPattern) => (aValue, aPattern))
+	.ModifyS(mSPO_AST.Is)
+	.SetName(nameof(Is));
 	
 	public static readonly mParserGen.tParser<tPos, tToken, mSPO_AST.tMethodCallNode<tSpan>, tError>
 	MethodCall = mParserGen.Seq(
@@ -710,6 +719,7 @@ mSPO_Parser {
 					Lambda.Cast<mSPO_AST.tExpressionNode<tSpan>>(),
 					Method.Cast<mSPO_AST.tExpressionNode<tSpan>>(),
 					Call.Cast<mSPO_AST.tExpressionNode<tSpan>>(),
+					Is.Cast<mSPO_AST.tExpressionNode<tSpan>>(),
 					Tuple.Cast<mSPO_AST.tExpressionNode<tSpan>>(),
 					Prefix.Cast<mSPO_AST.tExpressionNode<tSpan>>(),
 					Record.Cast<mSPO_AST.tExpressionNode<tSpan>>(),


### PR DESCRIPTION
## Summary
- add a dedicated `tIsNode` AST node, helpers, equality, and text rendering
- parse `(X §IS Y)` as the new AST form and infer it as `§BOOL`
- lower `§IS` into an equivalent `§IF … MATCH` expression and cover the additions with unit tests

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c018b2788329bf2897b6de2bffe7