### PR TITLE
Expose pair constructs in parser and type system

### DIFF
--- a/SPO_CS/src/mSPO2IL.cs
+++ b/SPO_CS/src/mSPO2IL.cs
@@ -564,6 +564,18 @@ mSPO2IL {
 				);
 				return ResultReg;
 			}
+				case mSPO_AST.tPairNode<tPos> { Pos: var Pos, Tail: var Tail, Head: var Head, TypeAnnotation: var Type }: {
+					if (!aDefConstructor.MapExpression(aModuleConstructor, Tail).Match(out var TailReg, out var Error)) {
+						return mResult.Fail(Error);
+					}
+					if (!aDefConstructor.MapExpression(aModuleConstructor, Head).Match(out var HeadReg, out Error)) {
+						return mResult.Fail(Error);
+					}
+					var ResultReg = aDefConstructor.CreateTempReg();
+					aDefConstructor.Commands.Push(mIL_AST.CreatePair(Pos, ResultReg, TailReg, HeadReg));
+					aDefConstructor.AddLocal(ResultReg, Type.AssertNotEmpty());
+					return ResultReg;
+				}
 			case mSPO_AST.tTupleNode<tPos> { Items: var Items, TypeAnnotation: var Type }: {
 				switch (Items.Take(2).ToArrayList().Size) {
 					case 0: {
@@ -1384,6 +1396,21 @@ mSPO2IL {
 				}
 				break;
 			}
+				case mSPO_AST.tMatchPairNode<tPos> { Tail: var Tail, Head: var Head }: {
+					var HeadReg = aDefConstructor.CreateTempReg();
+					aDefConstructor.Commands.Push(mIL_AST.GetSecond(PatternNode.Pos, HeadReg, aRegId));
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(HeadReg, Head.TypeAnnotation.AssertNotEmpty());
+					if (!aDefConstructor.MapMatch(Head, HeadReg, out aError)) {
+						return false;
+					}
+					var TailReg = aDefConstructor.CreateTempReg();
+					aDefConstructor.Commands.Push(mIL_AST.GetFirst(PatternNode.Pos, TailReg, aRegId));
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(TailReg, Tail.TypeAnnotation.AssertNotEmpty());
+					if (!aDefConstructor.MapMatch(Tail, TailReg, out aError)) {
+						return false;
+					}
+					break;
+				}
 			case mSPO_AST.tMatchTupleNode<tPos> { Items: var Items }: {
 				var RemainingReg = aRegId;
 				mAssert.AreEquals(Items.Take(2).ToArrayList().Size, 2u);

--- a/SPO_CS/src/mSPO_AST.cs
+++ b/SPO_CS/src/mSPO_AST.cs
@@ -144,6 +144,15 @@ mSPO_AST {
 		public mMaybe.tMaybe<mVM_Type.tType> TypeAnnotation { get; set; }
 		public mStream.tStream<tMatchNode<tPos>> Items;
 	}
+	[DebuggerDisplay(cDebuggerDisplay)]
+	public sealed record
+	tMatchPairNode<tPos> : tMatchItemNode<tPos> {
+		public tPos Pos { get; init; }
+		public mMaybe.tMaybe<mVM_Type.tType> TypeAnnotation { get; set; }
+		public tMatchNode<tPos> Tail = default!;
+		public tMatchNode<tPos> Head = default!;
+	}
+	
 	
 	[DebuggerDisplay(cDebuggerDisplay)]
 	public sealed record
@@ -307,6 +316,15 @@ mSPO_AST {
 		public mMaybe.tMaybe<mVM_Type.tType> TypeAnnotation { get; set; }
 		public mStream.tStream<tTypeNode<tPos>> Expressions;
 	}
+	[DebuggerDisplay(cDebuggerDisplay)]
+	public sealed record
+	tPairTypeNode<tPos> : tTypeNode<tPos> {
+		public tPos Pos { get; init; }
+		public mMaybe.tMaybe<mVM_Type.tType> TypeAnnotation { get; set; }
+		public tTypeNode<tPos> TailType = default!;
+		public tTypeNode<tPos> HeadType = default!;
+	}
+	
 	
 	[DebuggerDisplay(cDebuggerDisplay)]
 	public sealed record
@@ -421,6 +439,15 @@ mSPO_AST {
 		public mMaybe.tMaybe<mVM_Type.tType> TypeAnnotation { get; set; }
 		public mStream.tStream<tExpressionNode<tPos>> Items;
 	}
+	[DebuggerDisplay(cDebuggerDisplay)]
+	public sealed record
+	tPairNode<tPos> : tExpressionNode<tPos> {
+		public tPos Pos { get; init; }
+		public mMaybe.tMaybe<mVM_Type.tType> TypeAnnotation { get; set; }
+		public tExpressionNode<tPos> Tail = default!;
+		public tExpressionNode<tPos> Head = default!;
+	}
+	
 	
 	[DebuggerDisplay(cDebuggerDisplay)]
 	public sealed record
@@ -576,6 +603,17 @@ mSPO_AST {
 			Items = aItems
 		},
 	};
+	public static tPairNode<tPos>
+	Pair<tPos>(
+		tPos aPos,
+		tExpressionNode<tPos> aTail,
+		tExpressionNode<tPos> aHead
+	) => new() {
+		Pos = aPos,
+		Tail = aTail,
+		Head = aHead
+	};
+
 	
 	public static tPrefixTypeNode<tPos>
 	PrefixType<tPos>(
@@ -605,6 +643,17 @@ mSPO_AST {
 		Pos = aPos,
 		Expressions = aTypes,
 	};
+	public static tPairTypeNode<tPos>
+	PairType<tPos>(
+		tPos aPos,
+		tTypeNode<tPos> aTailType,
+		tTypeNode<tPos> aHeadType
+	) => new() {
+		Pos = aPos,
+		TailType = aTailType,
+		HeadType = aHeadType
+	};
+
 	
 	public static tSetTypeNode<tPos>
 	SetType<tPos>(
@@ -798,6 +847,17 @@ mSPO_AST {
 			Items = aItems
 		},
 	};
+	public static tMatchPairNode<tPos>
+	MatchPair<tPos>(
+		tPos aPos,
+		tMatchNode<tPos> aTail,
+		tMatchNode<tPos> aHead
+	) => new() {
+		Pos = aPos,
+		Tail = aTail,
+		Head = aHead
+	};
+
 	
 	public static tMatchNode<tPos>
 	Match<tPos>(
@@ -1019,6 +1079,13 @@ mSPO_AST {
 			case tMatchVarNode<tPos> Node1: {
 				return a2 is tMatchVarNode<tPos> Node2 && Node1.Id == Node2.Id;
 			}
+			case tMatchPairNode<tPos> Node1: {
+				return (
+					a2 is tMatchPairNode<tPos> Node2 &&
+					AreEqual(Node1.Tail, Node2.Tail) &&
+					AreEqual(Node1.Head, Node2.Head)
+				);
+			}
 			case tMatchTupleNode<tPos> Node1: {
 				return (
 					a2 is tMatchTupleNode<tPos> Node2 &&
@@ -1207,6 +1274,13 @@ mSPO_AST {
 			case tPipeToLeftNode<tPos>: {
 				break;
 			}
+			case tPairNode<tPos> Node1: {
+				return (
+					a2 is tPairNode<tPos> Node2 &&
+					AreEqual(Node1.Tail, Node2.Tail) &&
+					AreEqual(Node1.Head, Node2.Head)
+				);
+			}
 			case tTupleNode<tPos> Node1: {
 				return (
 					a2 is tTupleNode<tPos> Node2 &&
@@ -1265,6 +1339,7 @@ mSPO_AST {
 			tTextNode<t> Node => $"\"{Node.Value}\"",
 			tPrefixNode<t> Node => $"({____}#{Node.Prefix} {Node.Element.ToText(____)}{__})",
 			tVarToValNode<t> Node => $"({____}({__}§VAR_TO_VAL {Node.Obj.ToText(____)}{__})",
+			tPairNode<t> Node => $"[{____}{Node.Tail.ToText(____)} ; {Node.Head.ToText(____)}{__}]",
 			tTupleNode<t> Node => $"({Node.Items.Map(_ => ____ + _.ToText(____)).Join((a1, a2) => a1 + ", " + a2, "")}{__})",
 			tLambdaNode<t> Node => $"({____}{Node.Head.ToText(____)} => {Node.Body.ToText(____)}{__})",
 			tCallNode<t> Node => $"({____}.{Node.Func.ToText(____)} {Node.Arg.ToText(____)}{__})",
@@ -1288,6 +1363,7 @@ mSPO_AST {
 			tMatchFreeIdNode<t> Node => "§DEF " + Node.Id,
 			tMatchVarNode<t> Node => "§VAR " + Node.Id,
 			tMatchPrefixNode<t> Node => $"({____}#{Node.Prefix} {Node.Match.ToText(____)}{__})",
+			tMatchPairNode<t> Node => $"({____}{Node.Tail.ToText(____)} ; {Node.Head.ToText(____)}{__})",
 			tMatchTupleNode<t> Node => $"({____}{Node.Items.Map(_ => _.ToText(____)).Join((a1, a2) => a1 + ", " + a2, "")}{__})",
 			tMatchGuardNode<t> Node => $"({____}{Node.Match.ToText(____)} & {Node.Guard.ToText(____)}{__})",
 			
@@ -1303,6 +1379,7 @@ mSPO_AST {
 			tTypeTypeNode<t> Node => "§TYPE",
 			tPrefixTypeNode<t> Node => $"[{____}#{Node.Prefix} {Node.Expressions.Map(_ => _.ToText(____)).Join((a1, a2) => a1 + ", " + a2, "")}{__}]",
 			tTupleTypeNode<t> Node => $"[{____}{Node.Expressions.Map(_ => _.ToText(____)).Join((a1, a2) => a1 + ", " + a2, "")}{__}]",
+			tPairTypeNode<t> Node => $"[{____}{Node.TailType.ToText(____)} ; {Node.HeadType.ToText(____)}{__}]",
 			tSetTypeNode<t> Node => $"[{____}{Node.Expressions.Map(_ => _.ToText(____)).Join((a1, a2) => a1 + " | " + a2, "")}{__}]",
 			tVarTypeNode<t> Node => $"[{____}§VAR {Node.Type}]",
 			tGenericTypeNode<t> Node => $"[{____}{Node.HeadType.ToText(____)} <=> {Node.BodyType.ToText(____)}{__}]",

--- a/SPO_CS/src/mSPO_AST_Types.cs
+++ b/SPO_CS/src/mSPO_AST_Types.cs
@@ -50,6 +50,11 @@ mSPO_AST_Types {
 			mSPO_AST.tTypeNode<tPos> Type => (
 				Type.AsVM_Type(aScope)
 			),
+					mSPO_AST.tPairNode<tPos> Pair => Pair.Tail.UpdateTypes(aScope).ThenTry(
+						aTail => Pair.Head.UpdateTypes(aScope).Then(
+							aHead => mVM_Type.Pair(aTail, aHead)
+						)
+					),
 			mSPO_AST.tTupleNode<tPos> Tuple => (
 				Tuple.Items.Map(
 					_ => _.UpdateTypes(aScope)
@@ -371,6 +376,25 @@ mSPO_AST_Types {
 				);
 				break;
 			}
+				case mSPO_AST.tMatchPairNode<tPos> MatchPair: {
+					var TailType = mStd.cEmpty;
+					var HeadType = mStd.cEmpty;
+					if (aType.IsSome(out var Type)) {
+						if (!Type.IsPair(out var Tail, out var Head)) {
+							return mResult.Fail((MatchPair.Pos, $"cant unify '{MatchPair.ToText()}' and '{Type.ToText()}'"));
+						}
+						TailType = Tail;
+						HeadType = Head;
+					}
+					if (!UpdateMatchTypes(MatchPair.Tail, TailType, aTypeRelation, aScope).Match(out var TailRes, out var Error)) {
+						return mResult.Fail(Error);
+					}
+					if (!UpdateMatchTypes(MatchPair.Head, HeadType, aTypeRelation, TailRes.Scope).Match(out var HeadRes, out Error)) {
+						return mResult.Fail(Error);
+					}
+					Result = (mVM_Type.Pair(TailRes.Type, HeadRes.Type), HeadRes.Scope);
+					break;
+				}
 			case mSPO_AST.tMatchTupleNode<tPos> MatchTuple: {
 				var Types = mStream.Stream<mVM_Type.tType>([]);
 				var NewScope = aScope;
@@ -695,6 +719,14 @@ mSPO_AST_Types {
 				Result = mVM_Type.Any();
 				break;
 			}
+				case mSPO_AST.tPairTypeNode<tPos> PairType: {
+					Result = PairType.TailType.AsVM_Type(aScope).ThenTry(
+						Tail => PairType.HeadType.AsVM_Type(aScope).Then(
+							Head => mVM_Type.Pair(Tail, Head)
+						)
+					);
+					break;
+				}
 			case mSPO_AST.tTupleTypeNode<tPos> TupleType: {
 				var Types = mStream.Stream<mVM_Type.tType>([]);
 				foreach (var Expression in TupleType.Expressions.Reverse()) {

--- a/SPO_CS/src/mSPO_Lowering.cs
+++ b/SPO_CS/src/mSPO_Lowering.cs
@@ -55,6 +55,17 @@ mSPO_Lowering {
 				aElement
 			).Do(_ => { _.TypeAnnotation = Type; })
 		),
+			mSPO_AST.tPairNode<tPos> { Pos: var Pos, Tail: var Tail, Head: var Head, TypeAnnotation: var Type }
+			=> LowerExpression(Tail).ThenTry(
+				aTail => LowerExpression(Head).Then(
+					aHead => (mSPO_AST.tExpressionNode<tPos>)mSPO_AST.Pair(
+						Pos,
+						aTail,
+						aHead
+					).Do(_ => { _.TypeAnnotation = Type; })
+				)
+			),
+
 		mSPO_AST.tTupleNode<tPos> { Pos: var Pos, Items: var Items, TypeAnnotation: var Type }
 		=> Items.Map(LowerExpression).WhenAllThen(
 			aItems => mSPO_AST.Tuple(

--- a/SPO_CS/src/mSPO_Parser.Tests.cs
+++ b/SPO_CS/src/mSPO_Parser.Tests.cs
@@ -98,6 +98,23 @@ mSPO_Parser_Tests {
 					);
 				}
 			),
+			mTest.Test("Pair",
+				aStreamOut => {
+					mAssert.AreEquals(
+						mSPO_Parser.Expression.ParseText(
+							"[1;"BLA"]",
+							"",
+							_ => { aStreamOut(_()); }
+						),
+						mSPO_AST.Pair(
+							Span((1, 1), (1, 9)),
+							mSPO_AST.Int(Span((1, 2), (1, 2)), 1),
+							mSPO_AST.Text(Span((1, 4), (1, 8)), "BLA")
+						),
+						mSPO_AST.AreEqual
+					);
+				}
+			),
 			mTest.Test("Match1",
 				aStreamOut => {
 					mAssert.AreEquals(
@@ -130,6 +147,23 @@ mSPO_Parser_Tests {
 										mSPO_AST.Match(Span((1, 6), (1, 6)), mSPO_AST.Id(Span((1, 6), (1, 6)), "x"), mStd.cEmpty)
 									]
 								)
+							),
+							mStd.cEmpty
+						),
+						mSPO_AST.AreEqual
+					);
+				}
+			),
+			mTest.Test("MatchPair",
+				aStreamOut => {
+					mAssert.AreEquals(
+						mSPO_Parser.Match.ParseText("(xs;x)", "", _ => { aStreamOut(_()); }),
+						mSPO_AST.Match(
+							Span((1, 1), (1, 6)),
+							mSPO_AST.MatchPair(
+								Span((1, 1), (1, 6)),
+								mSPO_AST.Match(Span((1, 2), (1, 3)), mSPO_AST.Id(Span((1, 2), (1, 3)), "xs"), mStd.cEmpty),
+								mSPO_AST.Match(Span((1, 5), (1, 5)), mSPO_AST.Id(Span((1, 5), (1, 5)), "x"), mStd.cEmpty)
 							),
 							mStd.cEmpty
 						),
@@ -177,6 +211,19 @@ mSPO_Parser_Tests {
 									mSPO_AST.Id(Span((1, 6), (1, 6)), "x")
 								]
 							)
+						),
+						mSPO_AST.AreEqual
+					);
+				}
+			),
+			mTest.Test("PairType",
+				aStreamOut => {
+					mAssert.AreEquals(
+						mSPO_Parser.Type.ParseText("[INT;INT]", "", _ => { aStreamOut(_()); }),
+						mSPO_AST.PairType(
+							Span((1, 1), (1, 9)),
+							mSPO_AST.IntType(Span((1, 2), (1, 4))),
+							mSPO_AST.IntType(Span((1, 6), (1, 8)))
 						),
 						mSPO_AST.AreEqual
 					);

--- a/SPO_CS/src/mSPO_Parser.cs
+++ b/SPO_CS/src/mSPO_Parser.cs
@@ -189,11 +189,35 @@ mSPO_Parser {
 	.SetName(nameof(Block));
 	
 	public static readonly mParserGen.tParser<tPos, tToken, mSPO_AST.tExpressionNode<tSpan>, tError>
+	Pair = E( mParserGen.Seq(
+		PipeExpression | Expression,
+		-NLs_Token[0..1],
+		-SpecialToken(";"),
+		-NLs_Token[0..1],
+		PipeExpression | Expression
+	) )
+	.Modify((aTail, _, _, _, aHead) => (Tail: aTail, Head: aHead))
+	.ModifyS((aSpan, aPair) => mSPO_AST.Pair(aSpan, aPair.Tail, aPair.Head))
+	.SetName(nameof(Pair));
+
+	public static readonly mParserGen.tParser<tPos, tToken, mSPO_AST.tExpressionNode<tSpan>, tError>
 	Tuple = C( mParserGen.Seq(PipeExpression | Expression, ((-SpecialToken(",") | -NLs_Token) +(PipeExpression | Expression))[1..]) )
 	.Modify(mStream.Stream)
 	.ModifyS(mSPO_AST.Tuple)
 	.SetName(nameof(Tuple));
 	
+	public static readonly mParserGen.tParser<tPos, tToken, mSPO_AST.tMatchItemNode<tSpan>, tError>
+	MatchPair = C( mParserGen.Seq(
+		Match,
+		-NLs_Token[0..1],
+		-SpecialToken(";"),
+		-NLs_Token[0..1],
+		Match
+	) )
+	.Modify((aTail, _, _, _, aHead) => (Tail: aTail, Head: aHead))
+	.ModifyS((aSpan, aPair) => mSPO_AST.MatchPair(aSpan, aPair.Tail, aPair.Head))
+	.SetName(nameof(MatchPair));
+
 	public static readonly mParserGen.tParser<tPos, tToken, mSPO_AST.tMatchItemNode<tSpan>, tError>
 	MatchTuple = C( mParserGen.Seq(Match, ((-SpecialToken(",") | -NLs_Token) +Match)[0..]) )
 	.Modify(mStream.Stream)
@@ -406,6 +430,20 @@ mSPO_Parser {
 	.ModifyS(mSPO_AST.VarType)
 	.SetName(nameof(VarType));
 	
+	public static readonly mParserGen.tParser<tPos, tToken, mSPO_AST.tPairTypeNode<tSpan>, tError>
+	PairType = E(
+		mParserGen.Seq(
+			Type,
+			-NLs_Token[0..1],
+			-SpecialToken(";"),
+			-NLs_Token[0..1],
+			Type
+		)
+	)
+	.Modify((aTail, _, _, _, aHead) => (Tail: aTail, Head: aHead))
+	.ModifyS((aSpan, aPair) => mSPO_AST.PairType(aSpan, aPair.Tail, aPair.Head))
+	.SetName(nameof(PairType));
+
 	public static readonly mParserGen.tParser<tPos, tToken, mSPO_AST.tTupleTypeNode<tSpan>, tError>
 	TupleType = E(
 		mParserGen.Seq(
@@ -675,6 +713,7 @@ mSPO_Parser {
 					PrefixType.Cast<mSPO_AST.tTypeNode<tSpan>>(),
 					VarType.Cast<mSPO_AST.tTypeNode<tSpan>>(),
 					TupleType.Cast<mSPO_AST.tTypeNode<tSpan>>(),
+					PairType.Cast<mSPO_AST.tTypeNode<tSpan>>(),
 					SetType.Cast<mSPO_AST.tTypeNode<tSpan>>(),
 					LambdaType.Cast<mSPO_AST.tTypeNode<tSpan>>(),
 					RecursiveType.Cast<mSPO_AST.tTypeNode<tSpan>>(),
@@ -690,6 +729,7 @@ mSPO_Parser {
 				[
 					MatchFreeId.Cast<mSPO_AST.tMatchItemNode<tSpan>>(),
 					MatchVar.Cast<mSPO_AST.tMatchItemNode<tSpan>>(),
+					MatchPair.Cast<mSPO_AST.tMatchItemNode<tSpan>>(),
 					MatchTuple.Cast<mSPO_AST.tMatchItemNode<tSpan>>(),
 					IgnoreMatch.Cast<mSPO_AST.tMatchItemNode<tSpan>>(),
 					MatchPrefix.Cast<mSPO_AST.tMatchItemNode<tSpan>>(),
@@ -710,6 +750,7 @@ mSPO_Parser {
 					Lambda.Cast<mSPO_AST.tExpressionNode<tSpan>>(),
 					Method.Cast<mSPO_AST.tExpressionNode<tSpan>>(),
 					Call.Cast<mSPO_AST.tExpressionNode<tSpan>>(),
+					Pair.Cast<mSPO_AST.tExpressionNode<tSpan>>(),
 					Tuple.Cast<mSPO_AST.tExpressionNode<tSpan>>(),
 					Prefix.Cast<mSPO_AST.tExpressionNode<tSpan>>(),
 					Record.Cast<mSPO_AST.tExpressionNode<tSpan>>(),
@@ -726,6 +767,7 @@ mSPO_Parser {
 			mParserGen.OneOf(
 				[
 					Block.Cast<mSPO_AST.tExpressionNode<tSpan>>(),
+					Pair.Cast<mSPO_AST.tExpressionNode<tSpan>>(),
 					Tuple.Cast<mSPO_AST.tExpressionNode<tSpan>>(),
 					Record.Cast<mSPO_AST.tExpressionNode<tSpan>>(),
 					C( PipeExpression | Expression ).Cast<mSPO_AST.tExpressionNode<tSpan>>(),


### PR DESCRIPTION
## Summary
- add pair nodes to the SPO AST along with constructors, ToText helpers, and type inference support
- parse pair expressions, match patterns, and types and cover them with parser tests
- lower and emit IL for pair creation and matching so tuples can be deconstructed into head/tail pairs

## Testing
- not run (missing .NET 9 runtime)

------
https://chatgpt.com/codex/tasks/task_e_68d2f1327ee4832999554dfa0be43e2d