### PR TITLE
Rebuild match results into new registers

### DIFF
--- a/SPO_CS/src/mSPO2IL.cs
+++ b/SPO_CS/src/mSPO2IL.cs
@@ -328,7 +328,7 @@ mSPO2IL {
 		mSPO_AST.tLambdaNode<tPos> aLambdaNode
 	) {
 		if (
-			!aDefConstructor.MapMatch(aLambdaNode.Head, mIL_AST.cArg, out var Error) ||
+			!aDefConstructor.MapMatch(aLambdaNode.Head, mIL_AST.cArg).Match(out var _, out var Error) ||
 			!aDefConstructor.MapExpression(aModuleConstructor, aLambdaNode.Body).Match(out var ResultReg, out Error)
 		) {
 			return mResult.Fail(Error);
@@ -368,8 +368,8 @@ mSPO2IL {
 		mSPO_AST.tMethodNode<tPos> aMethodNode
 	) {
 		if (
-			!aDefConstructor.MapMatch(aMethodNode.Arg, mIL_AST.cArg, out var Error) ||
-			!aDefConstructor.MapMatch(aMethodNode.Obj, mIL_AST.cObj, out Error) ||
+			!aDefConstructor.MapMatch(aMethodNode.Arg, mIL_AST.cArg).Match(out var _, out var Error) ||
+			!aDefConstructor.MapMatch(aMethodNode.Obj, mIL_AST.cObj).Match(out var _, out Error) ||
 			!aDefConstructor.MapExpression(aModuleConstructor, aMethodNode.Body).Match(out var ResultReg, out Error)
 		) {
 			return mResult.Fail(Error);
@@ -1208,7 +1208,7 @@ mSPO2IL {
 				var LazyCaseDef = NewDefConstructor<tPos>();
 				
 				if (
-					!LazyCaseDef.MapMatch(Node.Match, mIL_AST.cArg, out aError) ||
+					!LazyCaseDef.MapMatch(Node.Match, mIL_AST.cArg).Match(out var _, out aError) ||
 					!LazyCaseDef.MapExpression(aModuleConstructor, aCase.Expression).Match(out var Res, out aError)
 				) {
 					return false;
@@ -1260,7 +1260,7 @@ mSPO2IL {
 				var LazyCaseDef = NewDefConstructor<tPos>();
 				
 				if (
-					!LazyCaseDef.MapMatch(aCase.Match, mIL_AST.cArg, out aError) ||
+					!LazyCaseDef.MapMatch(aCase.Match, mIL_AST.cArg).Match(out var _, out aError) ||
 					!LazyCaseDef.MapExpression(aModuleConstructor, aCase.Expression).Match(out var Res, out aError)
 				) {
 					return false;
@@ -1312,7 +1312,7 @@ mSPO2IL {
 				var LazyCaseDef = NewDefConstructor<tPos>();
 				
 				if (
-					!LazyCaseDef.MapMatch(aCase.Match, mIL_AST.cArg, out aError) ||
+					!LazyCaseDef.MapMatch(aCase.Match, mIL_AST.cArg).Match(out var _, out aError) ||
 					!LazyCaseDef.MapExpression(aModuleConstructor, aCase.Expression).Match(out var Res, out aError)
 				) {
 					return false;
@@ -1382,7 +1382,7 @@ mSPO2IL {
 			}
 			case mSPO_AST.tMatchGuardNode<tPos> Node: {
 				if (
-					!aTestAndCallCaseFunc.MapMatch(Node.Match, mIL_AST.cArg, out aError) ||
+					!aTestAndCallCaseFunc.MapMatch(Node.Match, mIL_AST.cArg).Match(out var _, out aError) ||
 					!aTestAndCallCaseFunc.MapExpression(aModuleConstructor, Node.Guard).Match(out var GuardRes, out aError)
 				) {
 					return false;
@@ -1412,144 +1412,215 @@ mSPO2IL {
 		return true;
 	}
 	
-	public static tBool
+			public static mResult.tResult<(tText Reg, mVM_Type.tType Type), (tPos Pos, tText Error)>
 	MapMatch<tPos>(
-		this ref tDefConstructor<tPos> aDefConstructor,
-		mSPO_AST.tMatchNode<tPos> aMatchNode,
-		tText aRegId,
-		out (tPos, tText) aError
+			this ref tDefConstructor<tPos> aDefConstructor,
+			mSPO_AST.tMatchNode<tPos> aMatchNode,
+			tText aRegId
 	) {
-		var PatternNode = aMatchNode.Pattern;
-		var TypeNode = aMatchNode.TypeExpression;
-		
-		switch (PatternNode) {
-			case mSPO_AST.tIdNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
-				mAssert.AreNotEquals(Name, "_");
-				aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
-				aDefConstructor.AddArg(Name, Type.AssertNotEmpty());
-				break;
+			var PatternNode = aMatchNode.Pattern;
+			var TypeNode = aMatchNode.TypeExpression;
+			var ResultType = aMatchNode.TypeAnnotation.AssertNotEmpty();
+			tText? ResultReg = default;
+
+			mResult.tResult<(tText Reg, mVM_Type.tType Type), (tPos Pos, tText Error)> Return(
+				tText aResultReg,
+				mVM_Type.tType aType
+			) {
+				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(aResultReg, aType);
+				return mResult.OK((aResultReg, aType)).WithErrorType<(tPos Pos, tText Error)>();
 			}
-			case mSPO_AST.tEmptyNode<tPos> { Pos: var Pos }: {
-				aDefConstructor.Commands.Push(
-					mIL_AST.ReturnIfNotEmpty(Pos, aRegId)
-				);
-				break;
-			}
-			case mSPO_AST.tIntNode<tPos> { Pos: var Pos, Value: var Value }: {
-				aDefConstructor.Commands.Push(
-					[
-						mIL_AST.TryAsInt(Pos, aDefConstructor.CreateTempReg(out var IntReg), aRegId),
-						mIL_AST.CreateInt(Pos, aDefConstructor.CreateTempReg(out var ExpectedIntReg), "" + Value),
-						mIL_AST.IntsAreEq(Pos, aDefConstructor.CreateTempReg(out var EqReg), IntReg, ExpectedIntReg),
-						mIL_AST.XOr(Pos, aDefConstructor.CreateTempReg(out var NotEqReg), EqReg, mIL_AST.cTrue),
-						mIL_AST.ReturnIf(Pos, NotEqReg, mIL_AST.cEmptyValue)
-					]
-				);
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(IntReg, mVM_Type.Int());
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ExpectedIntReg, mVM_Type.Int());
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(EqReg, mVM_Type.Bool());
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(NotEqReg, mVM_Type.Bool());
-				break;
-			}
-			case mSPO_AST.tMatchFreeIdNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
-				mAssert.AreNotEquals(Name, "_");
-				aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
-				aDefConstructor.AddArg(Name, Type.AssertNotEmpty());
-				break;
-			}
-			case mSPO_AST.tMatchVarNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
-				mAssert.AreNotEquals(Name, "_");
-				aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
-				aDefConstructor.AddArg(Name, Type.AssertNotEmpty());
-				break;
-			}
-			case mSPO_AST.tIgnoreMatchNode<tPos> IgnoreMatchNode: {
-				break;
-			}
-			case mSPO_AST.tMatchPrefixNode<tPos> { Pos: var Pos, Prefix: var Prefix, Match: var Match, TypeAnnotation: var Type }: {
-				aDefConstructor.Commands.Push(
-					mIL_AST.SubPrefix(Pos, aDefConstructor.CreateTempReg(out var ResultReg), Prefix, aRegId)
-				);
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, Type.AssertNotEmpty());
-				return aDefConstructor.MapMatch(Match, ResultReg, out aError);
-			}
-			case mSPO_AST.tMatchRecordNode<tPos> { Elements: var Elements, TypeAnnotation: var TypeAnnotation }: {
-				foreach (var (IdNode, Match) in Elements) {
-					aDefConstructor.Commands.Push(mIL_AST.GetField(IdNode.Pos, aDefConstructor.CreateTempReg(out var FieldReg), aRegId, IdNode.Id));
-					if (!aDefConstructor.MapMatch(Match, FieldReg, out aError)) {
-						return false;
-					}
+
+			switch (PatternNode) {
+				case mSPO_AST.tIdNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
+					mAssert.AreNotEquals(Name, "_");
+					aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
+					var Type_ = Type.AssertNotEmpty();
+					aDefConstructor.AddArg(Name, Type_);
+					ResultReg = Name;
+					ResultType = Type_;
+					break;
 				}
-				break;
-			}
-			case mSPO_AST.tMatchTupleNode<tPos> { Items: var Items }: {
-				var RemainingReg = aRegId;
-				mAssert.AreEquals(Items.Take(2).ToArrayList().Size, 2u);
-				foreach (var Item in Items.Reverse()) {
+				case mSPO_AST.tEmptyNode<tPos> { Pos: var Pos }: {
 					aDefConstructor.Commands.Push(
-						mIL_AST.GetSecond(PatternNode.Pos, aDefConstructor.CreateTempReg(out var ItemReg), RemainingReg)
+						mIL_AST.ReturnIfNotEmpty(Pos, aRegId)
 					);
-					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ItemReg, Item.TypeAnnotation.AssertNotEmpty());
-					if (!aDefConstructor.MapMatch(Item, ItemReg, out aError)) {
-						return false;
+					ResultType = mVM_Type.Empty();
+					break;
+				}
+				case mSPO_AST.tIntNode<tPos> { Pos: var Pos, Value: var Value }: {
+					aDefConstructor.Commands.Push(
+						[
+							mIL_AST.TryAsInt(Pos, aDefConstructor.CreateTempReg(out var IntReg), aRegId),
+							mIL_AST.CreateInt(Pos, aDefConstructor.CreateTempReg(out var ExpectedIntReg), "" + Value),
+							mIL_AST.IntsAreEq(Pos, aDefConstructor.CreateTempReg(out var EqReg), IntReg, ExpectedIntReg),
+							mIL_AST.XOr(Pos, aDefConstructor.CreateTempReg(out var NotEqReg), EqReg, mIL_AST.cTrue),
+							mIL_AST.ReturnIf(Pos, NotEqReg, mIL_AST.cEmptyValue)
+						]
+					);
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(IntReg, mVM_Type.Int());
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ExpectedIntReg, mVM_Type.Int());
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(EqReg, mVM_Type.Bool());
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(NotEqReg, mVM_Type.Bool());
+					ResultType = mVM_Type.Int();
+					break;
+				}
+				case mSPO_AST.tMatchFreeIdNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
+					mAssert.AreNotEquals(Name, "_");
+					aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
+					var Type_ = Type.AssertNotEmpty();
+					aDefConstructor.AddArg(Name, Type_);
+					ResultReg = Name;
+					ResultType = Type_;
+					break;
+				}
+				case mSPO_AST.tMatchVarNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
+					mAssert.AreNotEquals(Name, "_");
+					aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
+					var Type_ = Type.AssertNotEmpty();
+					aDefConstructor.AddArg(Name, Type_);
+					ResultReg = Name;
+					ResultType = Type_;
+					break;
+				}
+				case mSPO_AST.tIgnoreMatchNode<tPos> IgnoreMatchNode: {
+					break;
+				}
+				case mSPO_AST.tMatchPrefixNode<tPos> { Pos: var Pos, Prefix: var Prefix, Match: var Match, TypeAnnotation: var Type }: {
+					aDefConstructor.Commands.Push(
+						mIL_AST.SubPrefix(Pos, aDefConstructor.CreateTempReg(out var InnerReg), Prefix, aRegId)
+					);
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(InnerReg, Type.AssertNotEmpty());
+					if (!aDefConstructor.MapMatch(Match, InnerReg).Match(out var MatchResult, out var Error)) {
+						return mResult.Fail(Error);
 					}
 					aDefConstructor.Commands.Push(
-						mIL_AST.GetFirst(PatternNode.Pos, aDefConstructor.CreateTempReg(out var NewRestReg), RemainingReg)
+						mIL_AST.AddPrefix(Pos, aDefConstructor.CreateTempReg(out var PrefixReg), Prefix, MatchResult.Reg)
 					);
-					RemainingReg = NewRestReg;
+					ResultReg = PrefixReg;
+					ResultType = mVM_Type.Prefix(Prefix, MatchResult.Type);
+					break;
 				}
-				break;
-			}
-			case mSPO_AST.tMatchPairNode<tPos> { Tail: var Tail, Head: var Head }: {
-				
-				aDefConstructor.Commands.Push(
-					mIL_AST.GetSecond(PatternNode.Pos, aDefConstructor.CreateTempReg(out var HeadReg), aRegId)
-				);
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(HeadReg, Head.TypeAnnotation.AssertNotEmpty());
-				if (!aDefConstructor.MapMatch(Head, HeadReg, out aError)) {
-					return false;
-				}
-				
-				aDefConstructor.Commands.Push(
-					mIL_AST.GetFirst(PatternNode.Pos, aDefConstructor.CreateTempReg(out var TailReg), aRegId)
-				);
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(TailReg, Tail.TypeAnnotation.AssertNotEmpty());
-				if (!aDefConstructor.MapMatch(Tail, TailReg, out aError)) {
-					return false;
-				}
-				
-				break;
-			}
-			case mSPO_AST.tMatchGuardNode<tPos> { Match: var Match, Guard: var Guard }: {
-				// TODO: ASSERT Guard
-				return aDefConstructor.MapMatch(Match, aRegId, out aError);
-			}
-			case mSPO_AST.tMatchNode<tPos> MatchNode: {
-				if (TypeNode.IsSome(out var TypeNode_)) {
-					if (MatchNode.TypeExpression.IsSome(out var MatchTypeNode)) {
-						throw mError.Error("not implemented"); //TODO: Unify MatchTypeNode & TypeNode_
+				case mSPO_AST.tMatchRecordNode<tPos> { Elements: var Elements, TypeAnnotation: var TypeAnnotation }: {
+					var RecordReg = mIL_AST.cEmptyValue;
+					var RecordType = mVM_Type.Empty();
+					foreach (var (IdNode, Match) in Elements) {
+						aDefConstructor.Commands.Push(mIL_AST.GetField(IdNode.Pos, aDefConstructor.CreateTempReg(out var FieldReg), aRegId, IdNode.Id));
+						if (!aDefConstructor.MapMatch(Match, FieldReg).Match(out var FieldResult, out var Error)) {
+							return mResult.Fail(Error);
+						}
+						aDefConstructor.Commands.Push(
+							[
+								mIL_AST.AddPrefix(IdNode.Pos, aDefConstructor.CreateTempReg(out var PrefixReg), IdNode.Id, FieldResult.Reg),
+								mIL_AST.AddField(IdNode.Pos, aDefConstructor.CreateTempReg(out var NewRecordReg), RecordReg, PrefixReg),
+							]
+						);
+						RecordReg = NewRecordReg;
+						RecordType = mVM_Type.Record(
+							RecordType,
+							mVM_Type.Prefix(IdNode.Id, FieldResult.Type)
+						);
 					}
-					
-					return aDefConstructor.MapMatch(
-						mSPO_AST.Match(aMatchNode.Pos, MatchNode.Pattern, TypeNode),
-						aRegId,
-						out aError
+					ResultReg = RecordReg;
+					ResultType = RecordType;
+					break;
+				}
+				case mSPO_AST.tMatchTupleNode<tPos> { Items: var Items }: {
+					var RemainingReg = aRegId;
+					var ItemResults = mArrayList.List<(tText Reg, mVM_Type.tType Type)>();
+					var ItemTypes = mArrayList.List<mVM_Type.tType>();
+					mAssert.AreEquals(Items.Take(2).ToArrayList().Size, 2u);
+					foreach (var Item in Items.Reverse()) {
+						aDefConstructor.Commands.Push(
+							mIL_AST.GetSecond(PatternNode.Pos, aDefConstructor.CreateTempReg(out var ItemReg), RemainingReg)
+						);
+						aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ItemReg, Item.TypeAnnotation.AssertNotEmpty());
+						if (!aDefConstructor.MapMatch(Item, ItemReg).Match(out var ItemResult, out var Error)) {
+							return mResult.Fail(Error);
+						}
+						ItemResults.Push(ItemResult);
+						ItemTypes.Push(ItemResult.Type);
+						aDefConstructor.Commands.Push(
+							mIL_AST.GetFirst(PatternNode.Pos, aDefConstructor.CreateTempReg(out var NewRestReg), RemainingReg)
+						);
+						RemainingReg = NewRestReg;
+					}
+					var TupleReg = mIL_AST.cEmptyValue;
+					foreach (var ItemResult in ItemResults.ToStream().Reverse()) {
+						aDefConstructor.Commands.Push(
+							mIL_AST.CreatePair(
+								PatternNode.Pos,
+								aDefConstructor.CreateTempReg(out var NewTupleReg),
+								TupleReg,
+								ItemResult.Reg
+							)
+						);
+						TupleReg = NewTupleReg;
+					}
+					ResultReg = TupleReg;
+					ResultType = mVM_Type.Tuple(ItemTypes.ToStream().Reverse());
+					break;
+				}
+				case mSPO_AST.tMatchPairNode<tPos> { Tail: var Tail, Head: var Head }: {
+					aDefConstructor.Commands.Push(
+						mIL_AST.GetSecond(PatternNode.Pos, aDefConstructor.CreateTempReg(out var HeadReg), aRegId)
 					);
-				} else {
-					return aDefConstructor.MapMatch(MatchNode, aRegId, out aError);
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(HeadReg, Head.TypeAnnotation.AssertNotEmpty());
+					if (!aDefConstructor.MapMatch(Head, HeadReg).Match(out var HeadResult, out var Error)) {
+						return mResult.Fail(Error);
+					}
+
+					aDefConstructor.Commands.Push(
+						mIL_AST.GetFirst(PatternNode.Pos, aDefConstructor.CreateTempReg(out var TailReg), aRegId)
+					);
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(TailReg, Tail.TypeAnnotation.AssertNotEmpty());
+					if (!aDefConstructor.MapMatch(Tail, TailReg).Match(out var TailResult, out Error)) {
+						return mResult.Fail(Error);
+					}
+					aDefConstructor.Commands.Push(
+						mIL_AST.CreatePair(
+							PatternNode.Pos,
+							aDefConstructor.CreateTempReg(out var PairReg),
+							TailResult.Reg,
+							HeadResult.Reg
+						)
+					);
+					ResultReg = PairReg;
+					ResultType = mVM_Type.Pair(TailResult.Type, HeadResult.Type);
+					break;
+				}
+				case mSPO_AST.tMatchGuardNode<tPos> { Match: var Match, Guard: var Guard }: {
+					return aDefConstructor.MapMatch(Match, aRegId);
+				}
+				case mSPO_AST.tMatchNode<tPos> MatchNode: {
+					if (TypeNode.IsSome(out var TypeNode_)) {
+						if (MatchNode.TypeExpression.IsSome(out var MatchTypeNode)) {
+							throw mError.Error("not implemented"); //TODO: Unify MatchTypeNode & TypeNode_
+						}
+
+						return aDefConstructor.MapMatch(
+							mSPO_AST.Match(aMatchNode.Pos, MatchNode.Pattern, TypeNode),
+							aRegId
+						);
+					} else {
+						return aDefConstructor.MapMatch(MatchNode, aRegId);
+					}
+				}
+				default: {
+					throw mError.Error(
+						$"not implemented: {nameof(mSPO_AST)}.{PatternNode.GetType().Name} in {nameof(mSPO2IL)}.{nameof(MapMatch)}(...)"
+					);
 				}
 			}
-			default: {
-				throw mError.Error(
-					$"not implemented: {nameof(mSPO_AST)}.{PatternNode.GetType().Name} in {nameof(mSPO2IL)}.{nameof(MapMatch)}(...)"
-				);
+
+			if (ResultReg is null) {
+				aDefConstructor.CreateTempReg(out var AliasReg);
+				aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, AliasReg, aRegId));
+				ResultReg = AliasReg;
 			}
-		}
-		
-		aError = default;
-		return true;
+
+			return Return(ResultReg, ResultType);
 	}
-	
 	public static tBool
 	MapDef<tPos>(
 		this ref tDefConstructor<tPos> aDefConstructor,
@@ -1558,7 +1629,7 @@ mSPO2IL {
 		out (tPos Pos, tText ErrorText) aError
 	) => (
 		aDefConstructor.MapExpression(aModuleConstructor, aDefNode.Src).Match(out var ValueReg, out aError) &&
-		aDefConstructor.MapMatch(aDefNode.Des, ValueReg, out aError)
+		aDefConstructor.MapMatch(aDefNode.Des, ValueReg).Match(out var _, out aError)
 	);
 	
 	public static tBool
@@ -1820,7 +1891,7 @@ mSPO2IL {
 				]
 			);
 			if (Call.Result.IsSome(out var Result_)) {
-				if (!aDefConstructor.MapMatch(Result_, Result, out aError)) {
+				if (!aDefConstructor.MapMatch(Result_, Result).Match(out var _, out aError)) {
 					return false;
 				}
 			}


### PR DESCRIPTION
## Summary
- reconstruct prefix, record, tuple, and pair matches by building new registers from their validated child matches
- ensure primitive and ignored patterns still return a fresh register by aliasing the input when no new value was built

## Testing
- not run (environment lacks required .NET 9 runtime)


------
https://chatgpt.com/codex/tasks/task_e_68dd874db2448329acedb243f80726f9