### PR TITLE
Rebuild MapMatch result reconstruction

### DIFF
--- a/SPO_CS/src/mSPO2IL.cs
+++ b/SPO_CS/src/mSPO2IL.cs
@@ -328,7 +328,7 @@ mSPO2IL {
 		mSPO_AST.tLambdaNode<tPos> aLambdaNode
 	) {
 		if (
-			!aDefConstructor.MapMatch(aLambdaNode.Head, mIL_AST.cArg, out var Error) ||
+			!aDefConstructor.MapMatch(aLambdaNode.Head, mIL_AST.cArg).Match(out var _, out var Error) ||
 			!aDefConstructor.MapExpression(aModuleConstructor, aLambdaNode.Body).Match(out var ResultReg, out Error)
 		) {
 			return mResult.Fail(Error);
@@ -368,8 +368,8 @@ mSPO2IL {
 		mSPO_AST.tMethodNode<tPos> aMethodNode
 	) {
 		if (
-			!aDefConstructor.MapMatch(aMethodNode.Arg, mIL_AST.cArg, out var Error) ||
-			!aDefConstructor.MapMatch(aMethodNode.Obj, mIL_AST.cObj, out Error) ||
+			!aDefConstructor.MapMatch(aMethodNode.Arg, mIL_AST.cArg).Match(out var _, out var Error) ||
+			!aDefConstructor.MapMatch(aMethodNode.Obj, mIL_AST.cObj).Match(out var _, out Error) ||
 			!aDefConstructor.MapExpression(aModuleConstructor, aMethodNode.Body).Match(out var ResultReg, out Error)
 		) {
 			return mResult.Fail(Error);
@@ -1208,7 +1208,7 @@ mSPO2IL {
 				var LazyCaseDef = NewDefConstructor<tPos>();
 				
 				if (
-					!LazyCaseDef.MapMatch(Node.Match, mIL_AST.cArg, out aError) ||
+					!LazyCaseDef.MapMatch(Node.Match, mIL_AST.cArg).Match(out var _, out aError) ||
 					!LazyCaseDef.MapExpression(aModuleConstructor, aCase.Expression).Match(out var Res, out aError)
 				) {
 					return false;
@@ -1260,7 +1260,7 @@ mSPO2IL {
 				var LazyCaseDef = NewDefConstructor<tPos>();
 				
 				if (
-					!LazyCaseDef.MapMatch(aCase.Match, mIL_AST.cArg, out aError) ||
+					!LazyCaseDef.MapMatch(aCase.Match, mIL_AST.cArg).Match(out var _, out aError) ||
 					!LazyCaseDef.MapExpression(aModuleConstructor, aCase.Expression).Match(out var Res, out aError)
 				) {
 					return false;
@@ -1312,7 +1312,7 @@ mSPO2IL {
 				var LazyCaseDef = NewDefConstructor<tPos>();
 				
 				if (
-					!LazyCaseDef.MapMatch(aCase.Match, mIL_AST.cArg, out aError) ||
+					!LazyCaseDef.MapMatch(aCase.Match, mIL_AST.cArg).Match(out var _, out aError) ||
 					!LazyCaseDef.MapExpression(aModuleConstructor, aCase.Expression).Match(out var Res, out aError)
 				) {
 					return false;
@@ -1382,7 +1382,7 @@ mSPO2IL {
 			}
 			case mSPO_AST.tMatchGuardNode<tPos> Node: {
 				if (
-					!aTestAndCallCaseFunc.MapMatch(Node.Match, mIL_AST.cArg, out aError) ||
+					!aTestAndCallCaseFunc.MapMatch(Node.Match, mIL_AST.cArg).Match(out var _, out aError) ||
 					!aTestAndCallCaseFunc.MapExpression(aModuleConstructor, Node.Guard).Match(out var GuardRes, out aError)
 				) {
 					return false;
@@ -1412,144 +1412,208 @@ mSPO2IL {
 		return true;
 	}
 	
-	public static tBool
+		public static mResult.tResult<(tText Reg, mVM_Type.tType Type), (tPos Pos, tText Error)>
 	MapMatch<tPos>(
 		this ref tDefConstructor<tPos> aDefConstructor,
 		mSPO_AST.tMatchNode<tPos> aMatchNode,
-		tText aRegId,
-		out (tPos, tText) aError
+		tText aRegId
 	) {
 		var PatternNode = aMatchNode.Pattern;
 		var TypeNode = aMatchNode.TypeExpression;
-		
+		var ResultType = aMatchNode.TypeAnnotation.AssertNotEmpty();
+		tText ResultReg = default!;
+
 		switch (PatternNode) {
-			case mSPO_AST.tIdNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
-				mAssert.AreNotEquals(Name, "_");
-				aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
-				aDefConstructor.AddArg(Name, Type.AssertNotEmpty());
-				break;
+		case mSPO_AST.tIdNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
+			mAssert.AreNotEquals(Name, "_");
+			aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
+			var Type_ = Type.AssertNotEmpty();
+			aDefConstructor.AddArg(Name, Type_);
+			ResultType = Type_;
+			ResultReg = Name;
+			break;
+		}
+		case mSPO_AST.tEmptyNode<tPos> { Pos: var Pos }: {
+			aDefConstructor.Commands.Push(
+				mIL_AST.ReturnIfNotEmpty(Pos, aRegId)
+			);
+			ResultType = mVM_Type.Empty();
+			ResultReg = aDefConstructor.CreateTempReg(out var EmptyReg);
+			aDefConstructor.Commands.Push(mIL_AST.Alias(Pos, EmptyReg, aRegId));
+			aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(EmptyReg, ResultType);
+			break;
+		}
+		case mSPO_AST.tIntNode<tPos> { Pos: var Pos, Value: var Value }: {
+			aDefConstructor.Commands.Push(
+				[
+					mIL_AST.TryAsInt(Pos, aDefConstructor.CreateTempReg(out var IntReg), aRegId),
+					mIL_AST.CreateInt(Pos, aDefConstructor.CreateTempReg(out var ExpectedIntReg), "" + Value),
+					mIL_AST.IntsAreEq(Pos, aDefConstructor.CreateTempReg(out var EqReg), IntReg, ExpectedIntReg),
+					mIL_AST.XOr(Pos, aDefConstructor.CreateTempReg(out var NotEqReg), EqReg, mIL_AST.cTrue),
+					mIL_AST.ReturnIf(Pos, NotEqReg, mIL_AST.cEmptyValue)
+				]
+			);
+			aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(IntReg, mVM_Type.Int());
+			aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ExpectedIntReg, mVM_Type.Int());
+			aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(EqReg, mVM_Type.Bool());
+			aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(NotEqReg, mVM_Type.Bool());
+			ResultType = mVM_Type.Int();
+			ResultReg = IntReg;
+			break;
+		}
+		case mSPO_AST.tMatchFreeIdNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
+			mAssert.AreNotEquals(Name, "_");
+			aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
+			var Type_ = Type.AssertNotEmpty();
+			aDefConstructor.AddArg(Name, Type_);
+			ResultType = Type_;
+			ResultReg = Name;
+			break;
+		}
+		case mSPO_AST.tMatchVarNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
+			mAssert.AreNotEquals(Name, "_");
+			aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
+			var Type_ = Type.AssertNotEmpty();
+			aDefConstructor.AddArg(Name, Type_);
+			ResultType = Type_;
+			ResultReg = Name;
+			break;
+		}
+		case mSPO_AST.tIgnoreMatchNode<tPos> IgnoreMatchNode: {
+			ResultReg = aDefConstructor.CreateTempReg(out var IgnoredReg);
+			aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, IgnoredReg, aRegId));
+			aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(IgnoredReg, ResultType);
+			break;
+		}
+		case mSPO_AST.tMatchPrefixNode<tPos> { Pos: var Pos, Prefix: var Prefix, Match: var Match, TypeAnnotation: var Type }: {
+			aDefConstructor.Commands.Push(
+				mIL_AST.SubPrefix(Pos, aDefConstructor.CreateTempReg(out var SubReg), Prefix, aRegId)
+			);
+			aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(SubReg, Type.AssertNotEmpty());
+			if (!aDefConstructor.MapMatch(Match, SubReg).Match(out var MatchResult, out var Error)) {
+				return mResult.Fail(Error);
 			}
-			case mSPO_AST.tEmptyNode<tPos> { Pos: var Pos }: {
-				aDefConstructor.Commands.Push(
-					mIL_AST.ReturnIfNotEmpty(Pos, aRegId)
+			aDefConstructor.Commands.Push(
+				mIL_AST.AddPrefix(Pos, aDefConstructor.CreateTempReg(out var PrefixedReg), Prefix, MatchResult.Reg)
+			);
+			ResultReg = PrefixedReg;
+			ResultType = mVM_Type.Prefix(Prefix, MatchResult.Type);
+			aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, ResultType);
+			break;
+		}
+		case mSPO_AST.tMatchRecordNode<tPos> { Elements: var Elements, TypeAnnotation: var TypeAnnotation }: {
+			var RecordType = mVM_Type.Empty();
+			var FieldResults = mArrayList.List<(tPos Pos, tText Id, tText Reg, mVM_Type.tType Type)>();
+			foreach (var (IdNode, Match) in Elements) {
+				aDefConstructor.Commands.Push(mIL_AST.GetField(IdNode.Pos, aDefConstructor.CreateTempReg(out var FieldReg), aRegId, IdNode.Id));
+				if (!aDefConstructor.MapMatch(Match, FieldReg).Match(out var FieldResult, out var Error)) {
+					return mResult.Fail(Error);
+				}
+				RecordType = mVM_Type.Record(
+					RecordType,
+					mVM_Type.Prefix(IdNode.Id, FieldResult.Type)
 				);
-				break;
+				FieldResults.Push((IdNode.Pos, IdNode.Id, FieldResult.Reg, FieldResult.Type));
 			}
-			case mSPO_AST.tIntNode<tPos> { Pos: var Pos, Value: var Value }: {
+			var RecordReg = mIL_AST.cEmptyValue;
+			foreach (var (FieldPos, FieldId, FieldReg, _) in FieldResults.ToStream()) {
 				aDefConstructor.Commands.Push(
 					[
-						mIL_AST.TryAsInt(Pos, aDefConstructor.CreateTempReg(out var IntReg), aRegId),
-						mIL_AST.CreateInt(Pos, aDefConstructor.CreateTempReg(out var ExpectedIntReg), "" + Value),
-						mIL_AST.IntsAreEq(Pos, aDefConstructor.CreateTempReg(out var EqReg), IntReg, ExpectedIntReg),
-						mIL_AST.XOr(Pos, aDefConstructor.CreateTempReg(out var NotEqReg), EqReg, mIL_AST.cTrue),
-						mIL_AST.ReturnIf(Pos, NotEqReg, mIL_AST.cEmptyValue)
+						mIL_AST.AddPrefix(FieldPos, aDefConstructor.CreateTempReg(out var PrefixReg), FieldId, FieldReg),
+						mIL_AST.AddField(FieldPos, aDefConstructor.CreateTempReg(out var NewRecordReg), RecordReg, PrefixReg),
 					]
 				);
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(IntReg, mVM_Type.Int());
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ExpectedIntReg, mVM_Type.Int());
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(EqReg, mVM_Type.Bool());
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(NotEqReg, mVM_Type.Bool());
-				break;
+				RecordReg = NewRecordReg;
 			}
-			case mSPO_AST.tMatchFreeIdNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
-				mAssert.AreNotEquals(Name, "_");
-				aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
-				aDefConstructor.AddArg(Name, Type.AssertNotEmpty());
-				break;
-			}
-			case mSPO_AST.tMatchVarNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
-				mAssert.AreNotEquals(Name, "_");
-				aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
-				aDefConstructor.AddArg(Name, Type.AssertNotEmpty());
-				break;
-			}
-			case mSPO_AST.tIgnoreMatchNode<tPos> IgnoreMatchNode: {
-				break;
-			}
-			case mSPO_AST.tMatchPrefixNode<tPos> { Pos: var Pos, Prefix: var Prefix, Match: var Match, TypeAnnotation: var Type }: {
+			ResultReg = RecordReg;
+			ResultType = RecordType;
+			aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, ResultType);
+			break;
+		}
+		case mSPO_AST.tMatchTupleNode<tPos> { Items: var Items }: {
+			var RemainingReg = aRegId;
+			var ItemTypes = mArrayList.List<mVM_Type.tType>();
+			var ItemResults = mArrayList.List<(tText Reg, mVM_Type.tType Type)>();
+			mAssert.AreEquals(Items.Take(2).ToArrayList().Size, 2u);
+			foreach (var Item in Items.Reverse()) {
 				aDefConstructor.Commands.Push(
-					mIL_AST.SubPrefix(Pos, aDefConstructor.CreateTempReg(out var ResultReg), Prefix, aRegId)
+					mIL_AST.GetSecond(PatternNode.Pos, aDefConstructor.CreateTempReg(out var ItemReg), RemainingReg)
 				);
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, Type.AssertNotEmpty());
-				return aDefConstructor.MapMatch(Match, ResultReg, out aError);
-			}
-			case mSPO_AST.tMatchRecordNode<tPos> { Elements: var Elements, TypeAnnotation: var TypeAnnotation }: {
-				foreach (var (IdNode, Match) in Elements) {
-					aDefConstructor.Commands.Push(mIL_AST.GetField(IdNode.Pos, aDefConstructor.CreateTempReg(out var FieldReg), aRegId, IdNode.Id));
-					if (!aDefConstructor.MapMatch(Match, FieldReg, out aError)) {
-						return false;
-					}
+				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ItemReg, Item.TypeAnnotation.AssertNotEmpty());
+				if (!aDefConstructor.MapMatch(Item, ItemReg).Match(out var ItemResult, out var Error)) {
+					return mResult.Fail(Error);
 				}
-				break;
-			}
-			case mSPO_AST.tMatchTupleNode<tPos> { Items: var Items }: {
-				var RemainingReg = aRegId;
-				mAssert.AreEquals(Items.Take(2).ToArrayList().Size, 2u);
-				foreach (var Item in Items.Reverse()) {
-					aDefConstructor.Commands.Push(
-						mIL_AST.GetSecond(PatternNode.Pos, aDefConstructor.CreateTempReg(out var ItemReg), RemainingReg)
-					);
-					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ItemReg, Item.TypeAnnotation.AssertNotEmpty());
-					if (!aDefConstructor.MapMatch(Item, ItemReg, out aError)) {
-						return false;
-					}
-					aDefConstructor.Commands.Push(
-						mIL_AST.GetFirst(PatternNode.Pos, aDefConstructor.CreateTempReg(out var NewRestReg), RemainingReg)
-					);
-					RemainingReg = NewRestReg;
-				}
-				break;
-			}
-			case mSPO_AST.tMatchPairNode<tPos> { Tail: var Tail, Head: var Head }: {
-				
+				ItemTypes.Push(ItemResult.Type);
+				ItemResults.Push((ItemResult.Reg, ItemResult.Type));
 				aDefConstructor.Commands.Push(
-					mIL_AST.GetSecond(PatternNode.Pos, aDefConstructor.CreateTempReg(out var HeadReg), aRegId)
+					mIL_AST.GetFirst(PatternNode.Pos, aDefConstructor.CreateTempReg(out var NewRestReg), RemainingReg)
 				);
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(HeadReg, Head.TypeAnnotation.AssertNotEmpty());
-				if (!aDefConstructor.MapMatch(Head, HeadReg, out aError)) {
-					return false;
-				}
-				
+				RemainingReg = NewRestReg;
+			}
+			var TupleReg = mIL_AST.cEmptyValue;
+			foreach (var (ItemReg, _) in ItemResults.ToStream().Reverse()) {
 				aDefConstructor.Commands.Push(
-					mIL_AST.GetFirst(PatternNode.Pos, aDefConstructor.CreateTempReg(out var TailReg), aRegId)
+					mIL_AST.CreatePair(PatternNode.Pos, aDefConstructor.CreateTempReg(out var NewTupleReg), TupleReg, ItemReg)
 				);
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(TailReg, Tail.TypeAnnotation.AssertNotEmpty());
-				if (!aDefConstructor.MapMatch(Tail, TailReg, out aError)) {
-					return false;
+				TupleReg = NewTupleReg;
+			}
+			ResultReg = TupleReg;
+			ResultType = mVM_Type.Tuple(ItemTypes.ToStream().Reverse());
+			aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, ResultType);
+			break;
+		}
+		case mSPO_AST.tMatchPairNode<tPos> { Tail: var Tail, Head: var Head }: {
+			aDefConstructor.Commands.Push(
+				mIL_AST.GetSecond(PatternNode.Pos, aDefConstructor.CreateTempReg(out var HeadReg), aRegId)
+			);
+			aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(HeadReg, Head.TypeAnnotation.AssertNotEmpty());
+			if (!aDefConstructor.MapMatch(Head, HeadReg).Match(out var HeadResult, out var Error)) {
+				return mResult.Fail(Error);
+			}
+
+			aDefConstructor.Commands.Push(
+				mIL_AST.GetFirst(PatternNode.Pos, aDefConstructor.CreateTempReg(out var TailReg), aRegId)
+			);
+			aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(TailReg, Tail.TypeAnnotation.AssertNotEmpty());
+			if (!aDefConstructor.MapMatch(Tail, TailReg).Match(out var TailResult, out Error)) {
+				return mResult.Fail(Error);
+			}
+			aDefConstructor.Commands.Push(
+				mIL_AST.CreatePair(PatternNode.Pos, aDefConstructor.CreateTempReg(out var PairReg), TailResult.Reg, HeadResult.Reg)
+			);
+			ResultReg = PairReg;
+			ResultType = mVM_Type.Pair(TailResult.Type, HeadResult.Type);
+			aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, ResultType);
+			break;
+		}
+		case mSPO_AST.tMatchGuardNode<tPos> { Match: var Match, Guard: var Guard }: {
+			// TODO: ASSERT Guard
+			return aDefConstructor.MapMatch(Match, aRegId);
+		}
+		case mSPO_AST.tMatchNode<tPos> MatchNode: {
+			if (TypeNode.IsSome(out var TypeNode_)) {
+				if (MatchNode.TypeExpression.IsSome(out var MatchTypeNode)) {
+					throw mError.Error("not implemented"); //TODO: Unify MatchTypeNode & TypeNode_
 				}
-				
-				break;
-			}
-			case mSPO_AST.tMatchGuardNode<tPos> { Match: var Match, Guard: var Guard }: {
-				// TODO: ASSERT Guard
-				return aDefConstructor.MapMatch(Match, aRegId, out aError);
-			}
-			case mSPO_AST.tMatchNode<tPos> MatchNode: {
-				if (TypeNode.IsSome(out var TypeNode_)) {
-					if (MatchNode.TypeExpression.IsSome(out var MatchTypeNode)) {
-						throw mError.Error("not implemented"); //TODO: Unify MatchTypeNode & TypeNode_
-					}
-					
-					return aDefConstructor.MapMatch(
-						mSPO_AST.Match(aMatchNode.Pos, MatchNode.Pattern, TypeNode),
-						aRegId,
-						out aError
-					);
-				} else {
-					return aDefConstructor.MapMatch(MatchNode, aRegId, out aError);
-				}
-			}
-			default: {
-				throw mError.Error(
-					$"not implemented: {nameof(mSPO_AST)}.{PatternNode.GetType().Name} in {nameof(mSPO2IL)}.{nameof(MapMatch)}(...)"
+
+				return aDefConstructor.MapMatch(
+					mSPO_AST.Match(aMatchNode.Pos, MatchNode.Pattern, TypeNode),
+					aRegId
 				);
+			} else {
+				return aDefConstructor.MapMatch(MatchNode, aRegId);
 			}
 		}
-		
-		aError = default;
-		return true;
+		default: {
+			throw mError.Error(
+				$"not implemented: {nameof(mSPO_AST)}.{PatternNode.GetType().Name} in {nameof(mSPO2IL)}.{nameof(MapMatch)}(...)"
+			);
+		}
+		}
+
+		return mResult.OK((ResultReg, ResultType)).WithErrorType<(tPos Pos, tText Error)>();
 	}
-	
+
 	public static tBool
 	MapDef<tPos>(
 		this ref tDefConstructor<tPos> aDefConstructor,
@@ -1558,7 +1622,7 @@ mSPO2IL {
 		out (tPos Pos, tText ErrorText) aError
 	) => (
 		aDefConstructor.MapExpression(aModuleConstructor, aDefNode.Src).Match(out var ValueReg, out aError) &&
-		aDefConstructor.MapMatch(aDefNode.Des, ValueReg, out aError)
+		aDefConstructor.MapMatch(aDefNode.Des, ValueReg).Match(out var _, out aError)
 	);
 	
 	public static tBool
@@ -1820,7 +1884,7 @@ mSPO2IL {
 				]
 			);
 			if (Call.Result.IsSome(out var Result_)) {
-				if (!aDefConstructor.MapMatch(Result_, Result, out aError)) {
+				if (!aDefConstructor.MapMatch(Result_, Result).Match(out var _, out aError)) {
 					return false;
 				}
 			}


### PR DESCRIPTION
## Summary
- ensure `MapMatch` returns new registers instead of mutating the source binding and records their refined types
- rebuild composite pattern cases to reconstruct values from their submatches so the enclosing result carries the validated structure

## Testing
- not run (requires .NET 9 runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd874db2448329acedb243f80726f9