### PR TITLE
Refine MapMatch result handling

### DIFF
--- a/SPO_CS/src/mSPO2IL.Tests.cs
+++ b/SPO_CS/src/mSPO2IL.Tests.cs
@@ -203,20 +203,33 @@ mSPO2IL_Tests {
 								mIL_AST.CreateInt(Span((1, 38), (1, 38)), mSPO2IL.GetRegId(5), "3"), // [5]:3
 								mIL_AST.CreatePair(Span((1, 34), (1, 39)), mSPO2IL.GetRegId(6), mSPO2IL.GetRegId(4), mSPO2IL.GetRegId(5)), // [4]:(2); [5]:3 => (2, 3)
 								mIL_AST.CreatePair(Span((1, 30), (1, 40)), mSPO2IL.GetRegId(7), mSPO2IL.GetRegId(2), mSPO2IL.GetRegId(6)), // [2]:(1); [6]:(2, 3) => [7]:(1, (2, 3))
-								
-								mIL_AST.GetSecond(Span((1, 1), (1, 26)), mSPO2IL.GetRegId(8), mSPO2IL.GetRegId(7)), // [7]:(1, (2, 3)) => [8]:(2, 3)
-								mIL_AST.GetSecond(Span((1, 10), (1, 25)), mSPO2IL.GetRegId(9), mSPO2IL.GetRegId(8)), // [8]:(2, 3) => [9]:3
-								mIL_AST.Alias(Span((1, 19), (1, 24)), mSPO2IL.GetId("c"), mSPO2IL.GetRegId(9)), // [9]:3 == c
-								mIL_AST.GetFirst(Span((1, 10), (1, 25)), mSPO2IL.GetRegId(10), mSPO2IL.GetRegId(8)), // [8]:(2, 3) => [10]:(2)
-								mIL_AST.GetSecond(Span((1, 10), (1, 25)), mSPO2IL.GetRegId(11), mSPO2IL.GetRegId(10)), // [10]:(2) => [11]:2
-								mIL_AST.Alias(Span((1, 11), (1, 16)), mSPO2IL.GetId("b"), mSPO2IL.GetRegId(11)), // [11]:2 == b
-								mIL_AST.GetFirst(Span((1, 10), (1, 25)), mSPO2IL.GetRegId(12), mSPO2IL.GetRegId(10)), // [10]:(2) => [12]:()
-								mIL_AST.GetFirst(Span((1, 1), (1, 26)), mSPO2IL.GetRegId(13), mSPO2IL.GetRegId(7)), // [7]:(1, (2, 3)) => [13]:(1)
-								mIL_AST.GetSecond(Span((1, 1), (1, 26)), mSPO2IL.GetRegId(14), mSPO2IL.GetRegId(13)), // [13]:(1) => [14]:1
-								mIL_AST.Alias(Span((1, 2), (1, 7)), mSPO2IL.GetId("a"), mSPO2IL.GetRegId(14)), // [14]:1 == a
-								
-								mIL_AST.GetFirst(Span((1, 1), (1, 26)), mSPO2IL.GetRegId(15), mSPO2IL.GetRegId(13)) // [13]:(1) => [14]:()
-							]
+
+								mIL_AST.TryAsPair(Span((1, 1), (1, 26)), mSPO2IL.GetRegId(8), mSPO2IL.GetRegId(7)), // [7] => [8] pair
+								mIL_AST.GetSecond(Span((1, 1), (1, 26)), mSPO2IL.GetRegId(9), mSPO2IL.GetRegId(8)), // [8] => [9] head
+								mIL_AST.TryAsPair(Span((1, 10), (1, 25)), mSPO2IL.GetRegId(10), mSPO2IL.GetRegId(9)), // inner => [10] pair
+								mIL_AST.GetSecond(Span((1, 10), (1, 25)), mSPO2IL.GetRegId(11), mSPO2IL.GetRegId(10)), // [10] => [11] head
+								mIL_AST.Alias(Span((1, 19), (1, 24)), mSPO2IL.GetId("c"), mSPO2IL.GetRegId(11)), // [11]:3 == c
+								mIL_AST.Alias(Span((1, 19), (1, 24)), mSPO2IL.GetRegId(12), mSPO2IL.GetId("c")), // c => [12]
+								mIL_AST.GetFirst(Span((1, 10), (1, 25)), mSPO2IL.GetRegId(13), mSPO2IL.GetRegId(10)), // rest => [13]
+								mIL_AST.TryAsPair(Span((1, 10), (1, 25)), mSPO2IL.GetRegId(14), mSPO2IL.GetRegId(13)), // [13] => [14] pair
+								mIL_AST.GetSecond(Span((1, 10), (1, 25)), mSPO2IL.GetRegId(15), mSPO2IL.GetRegId(14)), // [14] => [15] head
+								mIL_AST.Alias(Span((1, 11), (1, 16)), mSPO2IL.GetId("b"), mSPO2IL.GetRegId(15)), // [15]:2 == b
+								mIL_AST.Alias(Span((1, 11), (1, 16)), mSPO2IL.GetRegId(16), mSPO2IL.GetId("b")), // b => [16]
+								mIL_AST.GetFirst(Span((1, 10), (1, 25)), mSPO2IL.GetRegId(17), mSPO2IL.GetRegId(14)), // rest => [17]
+								mIL_AST.ReturnIfNotEmpty(Span((1, 10), (1, 25)), mSPO2IL.GetRegId(17)), // ensure empty
+								mIL_AST.CreatePair(Span((1, 10), (1, 25)), mSPO2IL.GetRegId(18), mIL_AST.cEmptyValue, mSPO2IL.GetRegId(16)), // () ; b => [18]
+								mIL_AST.CreatePair(Span((1, 10), (1, 25)), mSPO2IL.GetRegId(19), mSPO2IL.GetRegId(18), mSPO2IL.GetRegId(12)), // [18]; c => [19]
+								mIL_AST.GetFirst(Span((1, 1), (1, 26)), mSPO2IL.GetRegId(20), mSPO2IL.GetRegId(8)), // rest => [20]
+								mIL_AST.TryAsPair(Span((1, 1), (1, 26)), mSPO2IL.GetRegId(21), mSPO2IL.GetRegId(20)), // [20] => [21] pair
+								mIL_AST.GetSecond(Span((1, 1), (1, 26)), mSPO2IL.GetRegId(22), mSPO2IL.GetRegId(21)), // [21] => [22] head
+								mIL_AST.Alias(Span((1, 2), (1, 7)), mSPO2IL.GetId("a"), mSPO2IL.GetRegId(22)), // [22]:1 == a
+								mIL_AST.Alias(Span((1, 2), (1, 7)), mSPO2IL.GetRegId(23), mSPO2IL.GetId("a")), // a => [23]
+								mIL_AST.GetFirst(Span((1, 1), (1, 26)), mSPO2IL.GetRegId(24), mSPO2IL.GetRegId(21)), // rest => [24]
+								mIL_AST.ReturnIfNotEmpty(Span((1, 1), (1, 26)), mSPO2IL.GetRegId(24)), // ensure empty
+								mIL_AST.CreatePair(Span((1, 1), (1, 26)), mSPO2IL.GetRegId(25), mIL_AST.cEmptyValue, mSPO2IL.GetRegId(23)), // () ; a => [25]
+								mIL_AST.CreatePair(Span((1, 1), (1, 26)), mSPO2IL.GetRegId(26), mSPO2IL.GetRegId(25), mSPO2IL.GetRegId(19)) // [25]; (b, c) => [26]
+								]
+
 						),
 						aAreEqual: mStream.Eq(mIL_AST.Eq_<tSpan>(EqSpan))
 					);
@@ -248,17 +261,27 @@ mSPO2IL_Tests {
 								mIL_AST.CreatePair(Span((1, 28), (1, 36)), mSPO2IL.GetRegId(4), mSPO2IL.GetRegId(2), mSPO2IL.GetRegId(3)), // [2]:(1); [3]:2 => [4]:(1, 2)
 								mIL_AST.CreateInt(Span((1, 35), (1, 35)), mSPO2IL.GetRegId(5), "3"), // [5]:3
 								mIL_AST.CreatePair(Span((1, 28), (1, 36)), mSPO2IL.GetRegId(6), mSPO2IL.GetRegId(4), mSPO2IL.GetRegId(5)), // [4]:(1, 2); [5]:3 => [6]:(1, 2, 3)
-								
-								mIL_AST.GetSecond(Span((1, 1), (1, 24)), mSPO2IL.GetRegId(7), mSPO2IL.GetRegId(6)), // [6]:(1, 2, 3) => [7]:3
-								mIL_AST.Alias(Span((1, 18), (1, 23)), mSPO2IL.GetId("c"), mSPO2IL.GetRegId(7)), // [7]:3 == c
-								mIL_AST.GetFirst(Span((1, 1), (1, 24)), mSPO2IL.GetRegId(8), mSPO2IL.GetRegId(6)), // [6]:(1, 2, 3) => [8]:(1, 2)
-								mIL_AST.GetSecond(Span((1, 1), (1, 24)), mSPO2IL.GetRegId(9), mSPO2IL.GetRegId(8)), // [8]:(1, 2) => [9]:2
-								mIL_AST.Alias(Span((1, 10), (1, 15)), mSPO2IL.GetId("b"), mSPO2IL.GetRegId(9)), // [9]:2 == b
-								mIL_AST.GetFirst(Span((1, 1), (1, 24)), mSPO2IL.GetRegId(10), mSPO2IL.GetRegId(8)), // [8]:(1, 2) => [10]:(1)
-								mIL_AST.GetSecond(Span((1, 1), (1, 24)), mSPO2IL.GetRegId(11), mSPO2IL.GetRegId(10)), // [10]:(1) => [11]:1
-								mIL_AST.Alias(Span((1, 2), (1, 7)), mSPO2IL.GetId("a"), mSPO2IL.GetRegId(11)), // [11]:1 == a
-								mIL_AST.GetFirst(Span((1, 1), (1, 24)), mSPO2IL.GetRegId(12), mSPO2IL.GetRegId(10)) // [10]:(1) => [12]:()
-							]
+
+								mIL_AST.TryAsPair(Span((1, 1), (1, 24)), mSPO2IL.GetRegId(7), mSPO2IL.GetRegId(6)), // [6] => [7] pair
+								mIL_AST.GetSecond(Span((1, 1), (1, 24)), mSPO2IL.GetRegId(8), mSPO2IL.GetRegId(7)), // [7] => [8] head
+								mIL_AST.Alias(Span((1, 18), (1, 23)), mSPO2IL.GetId("c"), mSPO2IL.GetRegId(8)), // [8]:3 == c
+								mIL_AST.Alias(Span((1, 18), (1, 23)), mSPO2IL.GetRegId(9), mSPO2IL.GetId("c")), // c => [9]
+								mIL_AST.GetFirst(Span((1, 1), (1, 24)), mSPO2IL.GetRegId(10), mSPO2IL.GetRegId(7)), // rest => [10]
+								mIL_AST.TryAsPair(Span((1, 1), (1, 24)), mSPO2IL.GetRegId(11), mSPO2IL.GetRegId(10)), // [10] => [11] pair
+								mIL_AST.GetSecond(Span((1, 1), (1, 24)), mSPO2IL.GetRegId(12), mSPO2IL.GetRegId(11)), // [11] => [12] head
+								mIL_AST.Alias(Span((1, 10), (1, 15)), mSPO2IL.GetId("b"), mSPO2IL.GetRegId(12)), // [12]:2 == b
+								mIL_AST.Alias(Span((1, 10), (1, 15)), mSPO2IL.GetRegId(13), mSPO2IL.GetId("b")), // b => [13]
+								mIL_AST.GetFirst(Span((1, 1), (1, 24)), mSPO2IL.GetRegId(14), mSPO2IL.GetRegId(11)), // rest => [14]
+								mIL_AST.TryAsPair(Span((1, 1), (1, 24)), mSPO2IL.GetRegId(15), mSPO2IL.GetRegId(14)), // [14] => [15] pair
+								mIL_AST.GetSecond(Span((1, 1), (1, 24)), mSPO2IL.GetRegId(16), mSPO2IL.GetRegId(15)), // [15] => [16] head
+								mIL_AST.Alias(Span((1, 2), (1, 7)), mSPO2IL.GetId("a"), mSPO2IL.GetRegId(16)), // [16]:1 == a
+								mIL_AST.Alias(Span((1, 2), (1, 7)), mSPO2IL.GetRegId(17), mSPO2IL.GetId("a")), // a => [17]
+								mIL_AST.GetFirst(Span((1, 1), (1, 24)), mSPO2IL.GetRegId(18), mSPO2IL.GetRegId(15)), // rest => [18]
+								mIL_AST.ReturnIfNotEmpty(Span((1, 1), (1, 24)), mSPO2IL.GetRegId(18)), // ensure empty
+								mIL_AST.CreatePair(Span((1, 1), (1, 24)), mSPO2IL.GetRegId(19), mIL_AST.cEmptyValue, mSPO2IL.GetRegId(17)), // () ; a => [19]
+								mIL_AST.CreatePair(Span((1, 1), (1, 24)), mSPO2IL.GetRegId(20), mSPO2IL.GetRegId(19), mSPO2IL.GetRegId(13)), // [19]; b => [20]
+								mIL_AST.CreatePair(Span((1, 1), (1, 24)), mSPO2IL.GetRegId(21), mSPO2IL.GetRegId(20), mSPO2IL.GetRegId(9)) // [20]; c => [21]
+								]
 						),
 						mStream.Eq(mIL_AST.Eq_<tSpan>(EqSpan))
 					);
@@ -293,25 +316,43 @@ mSPO2IL_Tests {
 								mIL_AST.CreatePair(Span((1, 59), (1, 64)), mSPO2IL.GetRegId(6), mIL_AST.cEmptyValue, mSPO2IL.GetRegId(5)), // (); [5]:3 => [6]:(3)
 								mIL_AST.CreateInt(Span((1, 63), (1, 63)), mSPO2IL.GetRegId(7), "4"), // 4 => [7]:4
 								mIL_AST.CreatePair(Span((1, 59), (1, 64)), mSPO2IL.GetRegId(8), mSPO2IL.GetRegId(6), mSPO2IL.GetRegId(7)), // [6]:(3); [7]:4 => [8]:(3, 4)
-								mIL_AST.AddPrefix(Span((1, 54), (1, 64)), mSPO2IL.GetRegId(9), mSPO2IL.GetId("bla..."), mSPO2IL.GetRegId(8)), // #bla[8]:(3, 4) => [9]:#bla(3, 4)
-								mIL_AST.CreatePair(Span((1, 46), (1, 66)), mSPO2IL.GetRegId(10), mSPO2IL.GetRegId(4), mSPO2IL.GetRegId(9)), // [4]:(1, 2); [8]:(#bla(3, 4)) => [10]:(1, 2, #bla(3, 4))
-								
-								mIL_AST.GetSecond(Span((1, 1), (1, 42)), mSPO2IL.GetRegId(11), mSPO2IL.GetRegId(10)), // [10]:(1, 2, #bla(3, 4)) => [11]:#bla(3, 4)
-								mIL_AST.SubPrefix(Span((1, 18), (1, 41)), mSPO2IL.GetRegId(12), mSPO2IL.GetId("bla..."), mSPO2IL.GetRegId(11)), // [11]:#bla(3, 4) => [12]:(3, 4)
-								mIL_AST.GetSecond(Span((1, 24), (1, 40)), mSPO2IL.GetRegId(13), mSPO2IL.GetRegId(12)), // [12]:(3, 4) => [13]:4
-								mIL_AST.Alias(Span((1, 34), (1, 39)), mSPO2IL.GetId("d"), mSPO2IL.GetRegId(13)), // [13]:4 == d
-								mIL_AST.GetFirst(Span((1, 24), (1, 40)), mSPO2IL.GetRegId(14), mSPO2IL.GetRegId(12)), // [12]:(3, 4) => [14]:(3)
-								mIL_AST.GetSecond(Span((1, 24), (1, 40)), mSPO2IL.GetRegId(15), mSPO2IL.GetRegId(14)), // [14]:(3) => [15]:3
-								mIL_AST.Alias(Span((1, 25), (1, 30)), mSPO2IL.GetId("c"), mSPO2IL.GetRegId(15)), // [15]:3 == c
-								mIL_AST.GetFirst(Span((1, 24), (1, 40)), mSPO2IL.GetRegId(16), mSPO2IL.GetRegId(14)), // [14]:(3) => [16]:()
-								mIL_AST.GetFirst(Span((1, 1), (1, 42)), mSPO2IL.GetRegId(17), mSPO2IL.GetRegId(10)), // [10]:(1, 2, #bla(3, 4)) => [17]:(1, 2)
-								mIL_AST.GetSecond(Span((1, 1), (1, 42)), mSPO2IL.GetRegId(18), mSPO2IL.GetRegId(17)), // [17]:(1, 2) => [18]:2
-								mIL_AST.Alias(Span((1, 10), (1, 15)), mSPO2IL.GetId("b"), mSPO2IL.GetRegId(18)), // [18]:2 == b
-								mIL_AST.GetFirst(Span((1, 1), (1, 42)), mSPO2IL.GetRegId(19), mSPO2IL.GetRegId(17)), // [17]:(1, 2) => [19]:(1)
-								mIL_AST.GetSecond(Span((1, 1), (1, 42)), mSPO2IL.GetRegId(20), mSPO2IL.GetRegId(19)), // [19]:(1) => [20]:1
-								mIL_AST.Alias(Span((1, 2), (1, 7)), mSPO2IL.GetId("a"), mSPO2IL.GetRegId(20)), // [20]:1 == a
-								mIL_AST.GetFirst(Span((1, 1), (1, 42)), mSPO2IL.GetRegId(21), mSPO2IL.GetRegId(19)) // [19]:(1) => [21]:()
-							]
+								mIL_AST.AddPrefix(Span((1, 54), (1, 64)), mSPO2IL.GetRegId(9), mSPO2IL.GetId("bla..."), mSPO2IL.GetRegId(8)), // #bla[8] => [9]
+								mIL_AST.CreatePair(Span((1, 46), (1, 66)), mSPO2IL.GetRegId(10), mSPO2IL.GetRegId(4), mSPO2IL.GetRegId(9)), // [4]; [9] => [10]
+
+								mIL_AST.TryAsPair(Span((1, 1), (1, 42)), mSPO2IL.GetRegId(11), mSPO2IL.GetRegId(10)), // [10] => [11] pair
+								mIL_AST.GetSecond(Span((1, 1), (1, 42)), mSPO2IL.GetRegId(12), mSPO2IL.GetRegId(11)), // [11] => [12] head
+								mIL_AST.SubPrefix(Span((1, 18), (1, 41)), mSPO2IL.GetRegId(13), mSPO2IL.GetId("bla..."), mSPO2IL.GetRegId(12)), // remove #bla
+								mIL_AST.TryAsPair(Span((1, 24), (1, 40)), mSPO2IL.GetRegId(14), mSPO2IL.GetRegId(13)), // inner => [14] pair
+								mIL_AST.GetSecond(Span((1, 24), (1, 40)), mSPO2IL.GetRegId(15), mSPO2IL.GetRegId(14)), // [14] => [15] head
+								mIL_AST.Alias(Span((1, 34), (1, 39)), mSPO2IL.GetId("d"), mSPO2IL.GetRegId(15)), // [15]:4 == d
+								mIL_AST.Alias(Span((1, 34), (1, 39)), mSPO2IL.GetRegId(16), mSPO2IL.GetId("d")), // d => [16]
+								mIL_AST.GetFirst(Span((1, 24), (1, 40)), mSPO2IL.GetRegId(17), mSPO2IL.GetRegId(14)), // rest => [17]
+								mIL_AST.TryAsPair(Span((1, 24), (1, 40)), mSPO2IL.GetRegId(18), mSPO2IL.GetRegId(17)), // [17] => [18] pair
+								mIL_AST.GetSecond(Span((1, 24), (1, 40)), mSPO2IL.GetRegId(19), mSPO2IL.GetRegId(18)), // [18] => [19] head
+								mIL_AST.Alias(Span((1, 25), (1, 30)), mSPO2IL.GetId("c"), mSPO2IL.GetRegId(19)), // [19]:3 == c
+								mIL_AST.Alias(Span((1, 25), (1, 30)), mSPO2IL.GetRegId(20), mSPO2IL.GetId("c")), // c => [20]
+								mIL_AST.GetFirst(Span((1, 24), (1, 40)), mSPO2IL.GetRegId(21), mSPO2IL.GetRegId(18)), // rest => [21]
+								mIL_AST.ReturnIfNotEmpty(Span((1, 24), (1, 40)), mSPO2IL.GetRegId(21)), // ensure empty
+								mIL_AST.CreatePair(Span((1, 24), (1, 40)), mSPO2IL.GetRegId(22), mIL_AST.cEmptyValue, mSPO2IL.GetRegId(20)), // () ; c => [22]
+								mIL_AST.CreatePair(Span((1, 24), (1, 40)), mSPO2IL.GetRegId(23), mSPO2IL.GetRegId(22), mSPO2IL.GetRegId(16)), // [22]; d => [23]
+								mIL_AST.AddPrefix(Span((1, 18), (1, 41)), mSPO2IL.GetRegId(24), mSPO2IL.GetId("bla..."), mSPO2IL.GetRegId(23)), // rebuild #bla => [24]
+								mIL_AST.GetFirst(Span((1, 1), (1, 42)), mSPO2IL.GetRegId(25), mSPO2IL.GetRegId(11)), // rest => [25]
+								mIL_AST.TryAsPair(Span((1, 1), (1, 42)), mSPO2IL.GetRegId(26), mSPO2IL.GetRegId(25)), // [25] => [26] pair
+								mIL_AST.GetSecond(Span((1, 1), (1, 42)), mSPO2IL.GetRegId(27), mSPO2IL.GetRegId(26)), // [26] => [27] head
+								mIL_AST.Alias(Span((1, 10), (1, 15)), mSPO2IL.GetId("b"), mSPO2IL.GetRegId(27)), // [27]:2 == b
+								mIL_AST.Alias(Span((1, 10), (1, 15)), mSPO2IL.GetRegId(28), mSPO2IL.GetId("b")), // b => [28]
+								mIL_AST.GetFirst(Span((1, 1), (1, 42)), mSPO2IL.GetRegId(29), mSPO2IL.GetRegId(26)), // rest => [29]
+								mIL_AST.TryAsPair(Span((1, 1), (1, 42)), mSPO2IL.GetRegId(30), mSPO2IL.GetRegId(29)), // [29] => [30] pair
+								mIL_AST.GetSecond(Span((1, 1), (1, 42)), mSPO2IL.GetRegId(31), mSPO2IL.GetRegId(30)), // [30] => [31] head
+								mIL_AST.Alias(Span((1, 2), (1, 7)), mSPO2IL.GetId("a"), mSPO2IL.GetRegId(31)), // [31]:1 == a
+								mIL_AST.Alias(Span((1, 2), (1, 7)), mSPO2IL.GetRegId(32), mSPO2IL.GetId("a")), // a => [32]
+								mIL_AST.GetFirst(Span((1, 1), (1, 42)), mSPO2IL.GetRegId(33), mSPO2IL.GetRegId(30)), // rest => [33]
+								mIL_AST.ReturnIfNotEmpty(Span((1, 1), (1, 42)), mSPO2IL.GetRegId(33)), // ensure empty
+								mIL_AST.CreatePair(Span((1, 1), (1, 42)), mSPO2IL.GetRegId(34), mIL_AST.cEmptyValue, mSPO2IL.GetRegId(32)), // () ; a => [34]
+								mIL_AST.CreatePair(Span((1, 1), (1, 42)), mSPO2IL.GetRegId(35), mSPO2IL.GetRegId(34), mSPO2IL.GetRegId(28)), // [34]; b => [35]
+								mIL_AST.CreatePair(Span((1, 1), (1, 42)), mSPO2IL.GetRegId(36), mSPO2IL.GetRegId(35), mSPO2IL.GetRegId(24)) // [35]; #bla => [36]
+								]
+
 						),
 						mStream.Eq(mIL_AST.Eq_<tSpan>(EqSpan))
 					);

--- a/SPO_CS/src/mSPO2IL.cs
+++ b/SPO_CS/src/mSPO2IL.cs
@@ -328,7 +328,7 @@ mSPO2IL {
 		mSPO_AST.tLambdaNode<tPos> aLambdaNode
 	) {
 		if (
-			!aDefConstructor.MapMatch(aLambdaNode.Head, mIL_AST.cArg, out var Error) ||
+			!aDefConstructor.MapMatch(aLambdaNode.Head, mIL_AST.cArg).Match(out _, out var Error) ||
 			!aDefConstructor.MapExpression(aModuleConstructor, aLambdaNode.Body).Match(out var ResultReg, out Error)
 		) {
 			return mResult.Fail(Error);
@@ -368,8 +368,8 @@ mSPO2IL {
 		mSPO_AST.tMethodNode<tPos> aMethodNode
 	) {
 		if (
-			!aDefConstructor.MapMatch(aMethodNode.Arg, mIL_AST.cArg, out var Error) ||
-			!aDefConstructor.MapMatch(aMethodNode.Obj, mIL_AST.cObj, out Error) ||
+			!aDefConstructor.MapMatch(aMethodNode.Arg, mIL_AST.cArg).Match(out _, out var Error) ||
+			!aDefConstructor.MapMatch(aMethodNode.Obj, mIL_AST.cObj).Match(out _, out Error) ||
 			!aDefConstructor.MapExpression(aModuleConstructor, aMethodNode.Body).Match(out var ResultReg, out Error)
 		) {
 			return mResult.Fail(Error);
@@ -1208,7 +1208,7 @@ mSPO2IL {
 				var LazyCaseDef = NewDefConstructor<tPos>();
 				
 				if (
-					!LazyCaseDef.MapMatch(Node.Match, mIL_AST.cArg, out aError) ||
+					!LazyCaseDef.MapMatch(Node.Match, mIL_AST.cArg).Match(out _, out aError) ||
 					!LazyCaseDef.MapExpression(aModuleConstructor, aCase.Expression).Match(out var Res, out aError)
 				) {
 					return false;
@@ -1260,7 +1260,7 @@ mSPO2IL {
 				var LazyCaseDef = NewDefConstructor<tPos>();
 				
 				if (
-					!LazyCaseDef.MapMatch(aCase.Match, mIL_AST.cArg, out aError) ||
+					!LazyCaseDef.MapMatch(aCase.Match, mIL_AST.cArg).Match(out _, out aError) ||
 					!LazyCaseDef.MapExpression(aModuleConstructor, aCase.Expression).Match(out var Res, out aError)
 				) {
 					return false;
@@ -1312,7 +1312,7 @@ mSPO2IL {
 				var LazyCaseDef = NewDefConstructor<tPos>();
 				
 				if (
-					!LazyCaseDef.MapMatch(aCase.Match, mIL_AST.cArg, out aError) ||
+					!LazyCaseDef.MapMatch(aCase.Match, mIL_AST.cArg).Match(out _, out aError) ||
 					!LazyCaseDef.MapExpression(aModuleConstructor, aCase.Expression).Match(out var Res, out aError)
 				) {
 					return false;
@@ -1382,7 +1382,7 @@ mSPO2IL {
 			}
 			case mSPO_AST.tMatchGuardNode<tPos> Node: {
 				if (
-					!aTestAndCallCaseFunc.MapMatch(Node.Match, mIL_AST.cArg, out aError) ||
+					!aTestAndCallCaseFunc.MapMatch(Node.Match, mIL_AST.cArg).Match(out _, out aError) ||
 					!aTestAndCallCaseFunc.MapExpression(aModuleConstructor, Node.Guard).Match(out var GuardRes, out aError)
 				) {
 					return false;
@@ -1412,28 +1412,49 @@ mSPO2IL {
 		return true;
 	}
 	
-	public static tBool
+		public static mResult.tResult<(tText Reg, mVM_Type.tType Type), (tPos Pos, tText ErrorText)>
 	MapMatch<tPos>(
 		this ref tDefConstructor<tPos> aDefConstructor,
 		mSPO_AST.tMatchNode<tPos> aMatchNode,
-		tText aRegId,
-		out (tPos, tText) aError
+		tText aRegId
 	) {
 		var PatternNode = aMatchNode.Pattern;
 		var TypeNode = aMatchNode.TypeExpression;
-		
+
 		switch (PatternNode) {
 			case mSPO_AST.tIdNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
 				mAssert.AreNotEquals(Name, "_");
 				aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
 				aDefConstructor.AddArg(Name, Type.AssertNotEmpty());
-				break;
+				aDefConstructor.Commands.Push(mIL_AST.Alias(Pos, aDefConstructor.CreateTempReg(out var ResultReg), Name));
+				var ResultType = Type.AssertNotEmpty();
+				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, ResultType);
+				return (ResultReg, ResultType);
 			}
-			case mSPO_AST.tEmptyNode<tPos> { Pos: var Pos }: {
-				aDefConstructor.Commands.Push(
-					mIL_AST.ReturnIfNotEmpty(Pos, aRegId)
-				);
-				break;
+			case mSPO_AST.tMatchFreeIdNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
+				mAssert.AreNotEquals(Name, "_");
+				aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
+				aDefConstructor.AddArg(Name, Type.AssertNotEmpty());
+				aDefConstructor.Commands.Push(mIL_AST.Alias(Pos, aDefConstructor.CreateTempReg(out var ResultReg), Name));
+				var ResultType = Type.AssertNotEmpty();
+				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, ResultType);
+				return (ResultReg, ResultType);
+			}
+			case mSPO_AST.tMatchVarNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
+				mAssert.AreNotEquals(Name, "_");
+				aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
+				aDefConstructor.AddArg(Name, Type.AssertNotEmpty());
+				aDefConstructor.Commands.Push(mIL_AST.Alias(Pos, aDefConstructor.CreateTempReg(out var ResultReg), Name));
+				var ResultType = Type.AssertNotEmpty();
+				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, ResultType);
+				return (ResultReg, ResultType);
+			}
+			case mSPO_AST.tEmptyNode<tPos> { Pos: var Pos, TypeAnnotation: var Type }: {
+				aDefConstructor.Commands.Push(mIL_AST.ReturnIfNotEmpty(Pos, aRegId));
+				aDefConstructor.Commands.Push(mIL_AST.Alias(Pos, aDefConstructor.CreateTempReg(out var ResultReg), aRegId));
+				var ResultType = Type.AssertNotEmpty();
+				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, ResultType);
+				return (ResultReg, ResultType);
 			}
 			case mSPO_AST.tIntNode<tPos> { Pos: var Pos, Value: var Value }: {
 				aDefConstructor.Commands.Push(
@@ -1449,94 +1470,117 @@ mSPO2IL {
 				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ExpectedIntReg, mVM_Type.Int());
 				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(EqReg, mVM_Type.Bool());
 				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(NotEqReg, mVM_Type.Bool());
-				break;
+				return (IntReg, mVM_Type.Int());
 			}
-			case mSPO_AST.tMatchFreeIdNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
-				mAssert.AreNotEquals(Name, "_");
-				aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
-				aDefConstructor.AddArg(Name, Type.AssertNotEmpty());
-				break;
+			case mSPO_AST.tIgnoreMatchNode<tPos> { Pos: var Pos, TypeAnnotation: var Type }: {
+				aDefConstructor.Commands.Push(mIL_AST.Alias(Pos, aDefConstructor.CreateTempReg(out var ResultReg), aRegId));
+				var ResultType = Type.AssertNotEmpty();
+				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, ResultType);
+				return (ResultReg, ResultType);
 			}
-			case mSPO_AST.tMatchVarNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
-				mAssert.AreNotEquals(Name, "_");
-				aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
-				aDefConstructor.AddArg(Name, Type.AssertNotEmpty());
-				break;
+			case mSPO_AST.tMatchPrefixNode<tPos> { Pos: var Pos, Prefix: var Prefix, Match: var Match }: {
+				aDefConstructor.Commands.Push(mIL_AST.SubPrefix(Pos, aDefConstructor.CreateTempReg(out var InnerReg), Prefix, aRegId));
+				var InnerType = Match.TypeAnnotation.AssertNotEmpty();
+				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(InnerReg, InnerType);
+				if (!aDefConstructor.MapMatch(Match, InnerReg).Match(out var InnerResult, out var Error)) {
+					return mResult.Fail(Error);
+				}
+				aDefConstructor.Commands.Push(mIL_AST.AddPrefix(Pos, aDefConstructor.CreateTempReg(out var ResultReg), Prefix, InnerResult.Reg));
+				var ResultType = mVM_Type.Prefix(Prefix, InnerResult.Type);
+				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, ResultType);
+				return (ResultReg, ResultType);
 			}
-			case mSPO_AST.tIgnoreMatchNode<tPos> IgnoreMatchNode: {
-				break;
-			}
-			case mSPO_AST.tMatchPrefixNode<tPos> { Pos: var Pos, Prefix: var Prefix, Match: var Match, TypeAnnotation: var Type }: {
-				aDefConstructor.Commands.Push(
-					mIL_AST.SubPrefix(Pos, aDefConstructor.CreateTempReg(out var ResultReg), Prefix, aRegId)
-				);
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, Type.AssertNotEmpty());
-				return aDefConstructor.MapMatch(Match, ResultReg, out aError);
-			}
-			case mSPO_AST.tMatchRecordNode<tPos> { Elements: var Elements, TypeAnnotation: var TypeAnnotation }: {
+			case mSPO_AST.tMatchRecordNode<tPos> { Elements: var Elements }: {
+				var MatchedFields = mArrayList.List<(tPos Pos, tText Id, tText ValueReg, mVM_Type.tType Type)>();
 				foreach (var (IdNode, Match) in Elements) {
 					aDefConstructor.Commands.Push(mIL_AST.GetField(IdNode.Pos, aDefConstructor.CreateTempReg(out var FieldReg), aRegId, IdNode.Id));
-					if (!aDefConstructor.MapMatch(Match, FieldReg, out aError)) {
-						return false;
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(FieldReg, Match.TypeAnnotation.AssertNotEmpty());
+					if (!aDefConstructor.MapMatch(Match, FieldReg).Match(out var FieldResult, out var Error)) {
+						return mResult.Fail(Error);
 					}
+					MatchedFields.Push((IdNode.Pos, IdNode.Id, FieldResult.Reg, FieldResult.Type));
 				}
-				break;
+				var ResultReg = mIL_AST.cEmptyValue;
+				var ResultType = mVM_Type.Empty();
+				foreach (var (FieldPos, FieldId, FieldValueReg, FieldValueType) in MatchedFields.ToStream()) {
+					aDefConstructor.Commands.Push(
+						[
+							mIL_AST.AddPrefix(FieldPos, aDefConstructor.CreateTempReg(out var PrefixReg), FieldId, FieldValueReg),
+							mIL_AST.AddField(FieldPos, aDefConstructor.CreateTempReg(out var NewResultReg), ResultReg, PrefixReg),
+						]
+					);
+					ResultReg = NewResultReg;
+					ResultType = mVM_Type.Record(ResultType, mVM_Type.Prefix(FieldId, FieldValueType));
+				}
+				if (ResultReg == mIL_AST.cEmptyValue) {
+					aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, aDefConstructor.CreateTempReg(out var EmptyReg), mIL_AST.cEmptyValue));
+					ResultReg = EmptyReg;
+				}
+				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, ResultType);
+				return (ResultReg, ResultType);
 			}
-			case mSPO_AST.tMatchTupleNode<tPos> { Items: var Items }: {
+			case mSPO_AST.tMatchTupleNode<tPos> { Pos: var Pos, Items: var Items }: {
+				var MatchedItems = mArrayList.List<(tText Reg, mVM_Type.tType Type)>();
 				var RemainingReg = aRegId;
-				mAssert.AreEquals(Items.Take(2).ToArrayList().Size, 2u);
 				foreach (var Item in Items.Reverse()) {
-					aDefConstructor.Commands.Push(
-						mIL_AST.GetSecond(PatternNode.Pos, aDefConstructor.CreateTempReg(out var ItemReg), RemainingReg)
-					);
+					aDefConstructor.Commands.Push(mIL_AST.TryAsPair(Pos, aDefConstructor.CreateTempReg(out var PairReg), RemainingReg));
+					aDefConstructor.Commands.Push(mIL_AST.GetSecond(Pos, aDefConstructor.CreateTempReg(out var ItemReg), PairReg));
 					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ItemReg, Item.TypeAnnotation.AssertNotEmpty());
-					if (!aDefConstructor.MapMatch(Item, ItemReg, out aError)) {
-						return false;
+					if (!aDefConstructor.MapMatch(Item, ItemReg).Match(out var ItemResult, out var Error)) {
+						return mResult.Fail(Error);
 					}
-					aDefConstructor.Commands.Push(
-						mIL_AST.GetFirst(PatternNode.Pos, aDefConstructor.CreateTempReg(out var NewRestReg), RemainingReg)
-					);
-					RemainingReg = NewRestReg;
+					MatchedItems.Push(ItemResult);
+					aDefConstructor.Commands.Push(mIL_AST.GetFirst(Pos, aDefConstructor.CreateTempReg(out var NewRemainingReg), PairReg));
+					RemainingReg = NewRemainingReg;
 				}
-				break;
+				aDefConstructor.Commands.Push(mIL_AST.ReturnIfNotEmpty(Pos, RemainingReg));
+				var ResultReg = mIL_AST.cEmptyValue;
+				var ResultType = mVM_Type.Empty();
+				foreach (var (ItemReg, ItemType) in MatchedItems.ToStream().Reverse()) {
+					aDefConstructor.Commands.Push(mIL_AST.CreatePair(Pos, aDefConstructor.CreateTempReg(out var NewTupleReg), ResultReg, ItemReg));
+					ResultReg = NewTupleReg;
+					ResultType = mVM_Type.Pair(ResultType, ItemType);
+				}
+				if (ResultReg == mIL_AST.cEmptyValue) {
+					aDefConstructor.Commands.Push(mIL_AST.Alias(Pos, aDefConstructor.CreateTempReg(out var EmptyTupleReg), mIL_AST.cEmptyValue));
+					ResultReg = EmptyTupleReg;
+				}
+				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, ResultType);
+				return (ResultReg, ResultType);
 			}
-			case mSPO_AST.tMatchPairNode<tPos> { Tail: var Tail, Head: var Head }: {
-				
-				aDefConstructor.Commands.Push(
-					mIL_AST.GetSecond(PatternNode.Pos, aDefConstructor.CreateTempReg(out var HeadReg), aRegId)
-				);
+			case mSPO_AST.tMatchPairNode<tPos> { Pos: var Pos, Tail: var Tail, Head: var Head }: {
+				aDefConstructor.Commands.Push(mIL_AST.TryAsPair(Pos, aDefConstructor.CreateTempReg(out var PairReg), aRegId));
+				aDefConstructor.Commands.Push(mIL_AST.GetSecond(Pos, aDefConstructor.CreateTempReg(out var HeadReg), PairReg));
 				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(HeadReg, Head.TypeAnnotation.AssertNotEmpty());
-				if (!aDefConstructor.MapMatch(Head, HeadReg, out aError)) {
-					return false;
+				if (!aDefConstructor.MapMatch(Head, HeadReg).Match(out var HeadResult, out var Error)) {
+					return mResult.Fail(Error);
 				}
-				
-				aDefConstructor.Commands.Push(
-					mIL_AST.GetFirst(PatternNode.Pos, aDefConstructor.CreateTempReg(out var TailReg), aRegId)
-				);
+				aDefConstructor.Commands.Push(mIL_AST.GetFirst(Pos, aDefConstructor.CreateTempReg(out var TailReg), PairReg));
 				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(TailReg, Tail.TypeAnnotation.AssertNotEmpty());
-				if (!aDefConstructor.MapMatch(Tail, TailReg, out aError)) {
-					return false;
+				if (!aDefConstructor.MapMatch(Tail, TailReg).Match(out var TailResult, out Error)) {
+					return mResult.Fail(Error);
 				}
-				
-				break;
+				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(PairReg, mVM_Type.Pair(TailResult.Type, HeadResult.Type));
+				aDefConstructor.Commands.Push(mIL_AST.CreatePair(Pos, aDefConstructor.CreateTempReg(out var ResultReg), TailResult.Reg, HeadResult.Reg));
+				var ResultType = mVM_Type.Pair(TailResult.Type, HeadResult.Type);
+				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, ResultType);
+				return (ResultReg, ResultType);
 			}
 			case mSPO_AST.tMatchGuardNode<tPos> { Match: var Match, Guard: var Guard }: {
-				// TODO: ASSERT Guard
-				return aDefConstructor.MapMatch(Match, aRegId, out aError);
+				return aDefConstructor.MapMatch(Match, aRegId);
 			}
 			case mSPO_AST.tMatchNode<tPos> MatchNode: {
 				if (TypeNode.IsSome(out var TypeNode_)) {
 					if (MatchNode.TypeExpression.IsSome(out var MatchTypeNode)) {
-						throw mError.Error("not implemented"); //TODO: Unify MatchTypeNode & TypeNode_
+						throw mError.Error("not implemented");
 					}
-					
+
 					return aDefConstructor.MapMatch(
 						mSPO_AST.Match(aMatchNode.Pos, MatchNode.Pattern, TypeNode),
-						aRegId,
-						out aError
+						aRegId
 					);
 				} else {
-					return aDefConstructor.MapMatch(MatchNode, aRegId, out aError);
+					return aDefConstructor.MapMatch(MatchNode, aRegId);
 				}
 			}
 			default: {
@@ -1545,22 +1589,26 @@ mSPO2IL {
 				);
 			}
 		}
-		
-		aError = default;
-		return true;
 	}
-	
+
 	public static tBool
 	MapDef<tPos>(
 		this ref tDefConstructor<tPos> aDefConstructor,
 		tModuleConstructor<tPos> aModuleConstructor,
 		mSPO_AST.tDefNode<tPos> aDefNode,
 		out (tPos Pos, tText ErrorText) aError
-	) => (
-		aDefConstructor.MapExpression(aModuleConstructor, aDefNode.Src).Match(out var ValueReg, out aError) &&
-		aDefConstructor.MapMatch(aDefNode.Des, ValueReg, out aError)
-	);
-	
+	) {
+		if (!aDefConstructor.MapExpression(aModuleConstructor, aDefNode.Src).Match(out var ValueReg, out aError)) {
+			return false;
+		}
+
+		if (!aDefConstructor.MapMatch(aDefNode.Des, ValueReg).Match(out _, out aError)) {
+			return false;
+		}
+
+		return true;
+	}
+
 	public static tBool
 	MapReturnIf<tPos>(
 		this ref tDefConstructor<tPos> aDefConstructor,
@@ -1820,7 +1868,7 @@ mSPO2IL {
 				]
 			);
 			if (Call.Result.IsSome(out var Result_)) {
-				if (!aDefConstructor.MapMatch(Result_, Result, out aError)) {
+				if (!aDefConstructor.MapMatch(Result_, Result).Match(out _, out aError)) {
 					return false;
 				}
 			}


### PR DESCRIPTION
## Summary
- update MapMatch to return a typed result, reconstruct matched values, and keep registers immutable
- adjust all MapMatch call sites to consume the new result shape
- refresh tuple and prefix pattern-matching expectations in tests

## Testing
- not run (missing .NET 9 runtime in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd9b257dcc8329aa922f478ad7a778