### PR TITLE
Refine MapMatch result handling

### DIFF
--- a/SPO_CS/src/mSPO2IL.cs
+++ b/SPO_CS/src/mSPO2IL.cs
@@ -328,7 +328,7 @@ mSPO2IL {
 		mSPO_AST.tLambdaNode<tPos> aLambdaNode
 	) {
 		if (
-			!aDefConstructor.MapMatch(aLambdaNode.Head, mIL_AST.cArg, out var Error) ||
+			!aDefConstructor.MapMatch(aLambdaNode.Head, mIL_AST.cArg).Match(out var _, out var Error) ||
 			!aDefConstructor.MapExpression(aModuleConstructor, aLambdaNode.Body).Match(out var ResultReg, out Error)
 		) {
 			return mResult.Fail(Error);
@@ -368,8 +368,8 @@ mSPO2IL {
 		mSPO_AST.tMethodNode<tPos> aMethodNode
 	) {
 		if (
-			!aDefConstructor.MapMatch(aMethodNode.Arg, mIL_AST.cArg, out var Error) ||
-			!aDefConstructor.MapMatch(aMethodNode.Obj, mIL_AST.cObj, out Error) ||
+			!aDefConstructor.MapMatch(aMethodNode.Arg, mIL_AST.cArg).Match(out var _, out var Error) ||
+			!aDefConstructor.MapMatch(aMethodNode.Obj, mIL_AST.cObj).Match(out var _, out Error) ||
 			!aDefConstructor.MapExpression(aModuleConstructor, aMethodNode.Body).Match(out var ResultReg, out Error)
 		) {
 			return mResult.Fail(Error);
@@ -1208,7 +1208,7 @@ mSPO2IL {
 				var LazyCaseDef = NewDefConstructor<tPos>();
 				
 				if (
-					!LazyCaseDef.MapMatch(Node.Match, mIL_AST.cArg, out aError) ||
+					!LazyCaseDef.MapMatch(Node.Match, mIL_AST.cArg).Match(out var _, out aError) ||
 					!LazyCaseDef.MapExpression(aModuleConstructor, aCase.Expression).Match(out var Res, out aError)
 				) {
 					return false;
@@ -1260,7 +1260,7 @@ mSPO2IL {
 				var LazyCaseDef = NewDefConstructor<tPos>();
 				
 				if (
-					!LazyCaseDef.MapMatch(aCase.Match, mIL_AST.cArg, out aError) ||
+					!LazyCaseDef.MapMatch(aCase.Match, mIL_AST.cArg).Match(out var _, out aError) ||
 					!LazyCaseDef.MapExpression(aModuleConstructor, aCase.Expression).Match(out var Res, out aError)
 				) {
 					return false;
@@ -1312,7 +1312,7 @@ mSPO2IL {
 				var LazyCaseDef = NewDefConstructor<tPos>();
 				
 				if (
-					!LazyCaseDef.MapMatch(aCase.Match, mIL_AST.cArg, out aError) ||
+					!LazyCaseDef.MapMatch(aCase.Match, mIL_AST.cArg).Match(out var _, out aError) ||
 					!LazyCaseDef.MapExpression(aModuleConstructor, aCase.Expression).Match(out var Res, out aError)
 				) {
 					return false;
@@ -1382,7 +1382,7 @@ mSPO2IL {
 			}
 			case mSPO_AST.tMatchGuardNode<tPos> Node: {
 				if (
-					!aTestAndCallCaseFunc.MapMatch(Node.Match, mIL_AST.cArg, out aError) ||
+					!aTestAndCallCaseFunc.MapMatch(Node.Match, mIL_AST.cArg).Match(out var _, out aError) ||
 					!aTestAndCallCaseFunc.MapExpression(aModuleConstructor, Node.Guard).Match(out var GuardRes, out aError)
 				) {
 					return false;
@@ -1412,143 +1412,166 @@ mSPO2IL {
 		return true;
 	}
 	
-	public static tBool
-	MapMatch<tPos>(
-		this ref tDefConstructor<tPos> aDefConstructor,
-		mSPO_AST.tMatchNode<tPos> aMatchNode,
-		tText aRegId,
-		out (tPos, tText) aError
-	) {
-		var PatternNode = aMatchNode.Pattern;
-		var TypeNode = aMatchNode.TypeExpression;
-		
-		switch (PatternNode) {
-			case mSPO_AST.tIdNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
-				mAssert.AreNotEquals(Name, "_");
-				aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
-				aDefConstructor.AddArg(Name, Type.AssertNotEmpty());
-				break;
-			}
-			case mSPO_AST.tEmptyNode<tPos> { Pos: var Pos }: {
-				aDefConstructor.Commands.Push(
-					mIL_AST.ReturnIfNotEmpty(Pos, aRegId)
-				);
-				break;
-			}
-			case mSPO_AST.tIntNode<tPos> { Pos: var Pos, Value: var Value }: {
-				aDefConstructor.Commands.Push(
-					[
-						mIL_AST.TryAsInt(Pos, aDefConstructor.CreateTempReg(out var IntReg), aRegId),
-						mIL_AST.CreateInt(Pos, aDefConstructor.CreateTempReg(out var ExpectedIntReg), "" + Value),
-						mIL_AST.IntsAreEq(Pos, aDefConstructor.CreateTempReg(out var EqReg), IntReg, ExpectedIntReg),
-						mIL_AST.XOr(Pos, aDefConstructor.CreateTempReg(out var NotEqReg), EqReg, mIL_AST.cTrue),
-						mIL_AST.ReturnIf(Pos, NotEqReg, mIL_AST.cEmptyValue)
-					]
-				);
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(IntReg, mVM_Type.Int());
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ExpectedIntReg, mVM_Type.Int());
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(EqReg, mVM_Type.Bool());
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(NotEqReg, mVM_Type.Bool());
-				break;
-			}
-			case mSPO_AST.tMatchFreeIdNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
-				mAssert.AreNotEquals(Name, "_");
-				aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
-				aDefConstructor.AddArg(Name, Type.AssertNotEmpty());
-				break;
-			}
-			case mSPO_AST.tMatchVarNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
-				mAssert.AreNotEquals(Name, "_");
-				aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
-				aDefConstructor.AddArg(Name, Type.AssertNotEmpty());
-				break;
-			}
-			case mSPO_AST.tIgnoreMatchNode<tPos> IgnoreMatchNode: {
-				break;
-			}
-			case mSPO_AST.tMatchPrefixNode<tPos> { Pos: var Pos, Prefix: var Prefix, Match: var Match, TypeAnnotation: var Type }: {
-				aDefConstructor.Commands.Push(
-					mIL_AST.SubPrefix(Pos, aDefConstructor.CreateTempReg(out var ResultReg), Prefix, aRegId)
-				);
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, Type.AssertNotEmpty());
-				return aDefConstructor.MapMatch(Match, ResultReg, out aError);
-			}
-			case mSPO_AST.tMatchRecordNode<tPos> { Elements: var Elements, TypeAnnotation: var TypeAnnotation }: {
-				foreach (var (IdNode, Match) in Elements) {
-					aDefConstructor.Commands.Push(mIL_AST.GetField(IdNode.Pos, aDefConstructor.CreateTempReg(out var FieldReg), aRegId, IdNode.Id));
-					if (!aDefConstructor.MapMatch(Match, FieldReg, out aError)) {
-						return false;
-					}
+		public static mResult.tResult<(tText Reg, mVM_Type.tType Type), (tPos Pos, tText Error)>
+		MapMatch<tPos>(
+			this ref tDefConstructor<tPos> aDefConstructor,
+			mSPO_AST.tMatchNode<tPos> aMatchNode,
+			tText aRegId
+		) {
+			var PatternNode = aMatchNode.Pattern;
+			var TypeNode = aMatchNode.TypeExpression;
+
+			switch (PatternNode) {
+				case mSPO_AST.tIdNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
+					mAssert.AreNotEquals(Name, "_");
+					aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
+					var ResultType = Type.AssertNotEmpty();
+					aDefConstructor.AddArg(Name, ResultType);
+					return mResult.OK((Name, ResultType)).WithErrorType<(tPos Pos, tText Error)>();
 				}
-				break;
-			}
-			case mSPO_AST.tMatchTupleNode<tPos> { Items: var Items }: {
-				var RemainingReg = aRegId;
-				mAssert.AreEquals(Items.Take(2).ToArrayList().Size, 2u);
-				foreach (var Item in Items.Reverse()) {
+				case mSPO_AST.tEmptyNode<tPos> { Pos: var Pos }: {
 					aDefConstructor.Commands.Push(
-						mIL_AST.GetSecond(PatternNode.Pos, aDefConstructor.CreateTempReg(out var ItemReg), RemainingReg)
+						mIL_AST.ReturnIfNotEmpty(Pos, aRegId)
 					);
-					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ItemReg, Item.TypeAnnotation.AssertNotEmpty());
-					if (!aDefConstructor.MapMatch(Item, ItemReg, out aError)) {
-						return false;
-					}
+					aDefConstructor.CreateTempReg(out var ResultReg);
+					aDefConstructor.Commands.Push(mIL_AST.Alias(Pos, ResultReg, aRegId));
+					var ResultType = mVM_Type.Empty();
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, ResultType);
+					return mResult.OK((ResultReg, ResultType)).WithErrorType<(tPos Pos, tText Error)>();
+				}
+				case mSPO_AST.tIntNode<tPos> { Pos: var Pos, Value: var Value }: {
 					aDefConstructor.Commands.Push(
-						mIL_AST.GetFirst(PatternNode.Pos, aDefConstructor.CreateTempReg(out var NewRestReg), RemainingReg)
+						[
+							mIL_AST.TryAsInt(Pos, aDefConstructor.CreateTempReg(out var IntReg), aRegId),
+							mIL_AST.CreateInt(Pos, aDefConstructor.CreateTempReg(out var ExpectedIntReg), "" + Value),
+							mIL_AST.IntsAreEq(Pos, aDefConstructor.CreateTempReg(out var EqReg), IntReg, ExpectedIntReg),
+							mIL_AST.XOr(Pos, aDefConstructor.CreateTempReg(out var NotEqReg), EqReg, mIL_AST.cTrue),
+							mIL_AST.ReturnIf(Pos, NotEqReg, mIL_AST.cEmptyValue)
+						]
 					);
-					RemainingReg = NewRestReg;
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(IntReg, mVM_Type.Int());
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ExpectedIntReg, mVM_Type.Int());
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(EqReg, mVM_Type.Bool());
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(NotEqReg, mVM_Type.Bool());
+					var ResultType = mVM_Type.Int();
+					return mResult.OK((IntReg, ResultType)).WithErrorType<(tPos Pos, tText Error)>();
 				}
-				break;
-			}
-			case mSPO_AST.tMatchPairNode<tPos> { Tail: var Tail, Head: var Head }: {
-				
-				aDefConstructor.Commands.Push(
-					mIL_AST.GetSecond(PatternNode.Pos, aDefConstructor.CreateTempReg(out var HeadReg), aRegId)
-				);
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(HeadReg, Head.TypeAnnotation.AssertNotEmpty());
-				if (!aDefConstructor.MapMatch(Head, HeadReg, out aError)) {
-					return false;
+				case mSPO_AST.tMatchFreeIdNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
+					mAssert.AreNotEquals(Name, "_");
+					aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
+					var ResultType = Type.AssertNotEmpty();
+					aDefConstructor.AddArg(Name, ResultType);
+					return mResult.OK((Name, ResultType)).WithErrorType<(tPos Pos, tText Error)>();
 				}
-				
-				aDefConstructor.Commands.Push(
-					mIL_AST.GetFirst(PatternNode.Pos, aDefConstructor.CreateTempReg(out var TailReg), aRegId)
-				);
-				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(TailReg, Tail.TypeAnnotation.AssertNotEmpty());
-				if (!aDefConstructor.MapMatch(Tail, TailReg, out aError)) {
-					return false;
+				case mSPO_AST.tMatchVarNode<tPos> { Pos: var Pos, Id: var Name, TypeAnnotation: var Type }: {
+					mAssert.AreNotEquals(Name, "_");
+					aDefConstructor.Commands.Push(mIL_AST.Alias(aMatchNode.Pos, Name, aRegId));
+					var ResultType = Type.AssertNotEmpty();
+					aDefConstructor.AddArg(Name, ResultType);
+					return mResult.OK((Name, ResultType)).WithErrorType<(tPos Pos, tText Error)>();
 				}
-				
-				break;
-			}
-			case mSPO_AST.tMatchGuardNode<tPos> { Match: var Match, Guard: var Guard }: {
-				// TODO: ASSERT Guard
-				return aDefConstructor.MapMatch(Match, aRegId, out aError);
-			}
-			case mSPO_AST.tMatchNode<tPos> MatchNode: {
-				if (TypeNode.IsSome(out var TypeNode_)) {
-					if (MatchNode.TypeExpression.IsSome(out var MatchTypeNode)) {
-						throw mError.Error("not implemented"); //TODO: Unify MatchTypeNode & TypeNode_
+				case mSPO_AST.tIgnoreMatchNode<tPos> IgnoreMatchNode: {
+					aDefConstructor.CreateTempReg(out var ResultReg);
+					aDefConstructor.Commands.Push(mIL_AST.Alias(IgnoreMatchNode.Pos, ResultReg, aRegId));
+					var ResultType = IgnoreMatchNode.TypeAnnotation.AssertNotEmpty();
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, ResultType);
+					return mResult.OK((ResultReg, ResultType)).WithErrorType<(tPos Pos, tText Error)>();
+				}
+				case mSPO_AST.tMatchPrefixNode<tPos> { Pos: var Pos, Prefix: var Prefix, Match: var Match, TypeAnnotation: var Type }: {
+					aDefConstructor.CreateTempReg(out var ResultReg);
+					aDefConstructor.Commands.Push(
+						mIL_AST.SubPrefix(Pos, ResultReg, Prefix, aRegId)
+					);
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, Type.AssertNotEmpty());
+					return aDefConstructor.MapMatch(Match, ResultReg);
+				}
+				case mSPO_AST.tMatchRecordNode<tPos> { Elements: var Elements, TypeAnnotation: var TypeAnnotation }: {
+					foreach (var (IdNode, Match) in Elements) {
+						aDefConstructor.CreateTempReg(out var FieldReg);
+						aDefConstructor.Commands.Push(mIL_AST.GetField(IdNode.Pos, FieldReg, aRegId, IdNode.Id));
+						aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(FieldReg, Match.TypeAnnotation.AssertNotEmpty());
+						if (!aDefConstructor.MapMatch(Match, FieldReg).Match(out var _, out var Error)) {
+							return mResult.Fail(Error);
+						}
 					}
-					
-					return aDefConstructor.MapMatch(
-						mSPO_AST.Match(aMatchNode.Pos, MatchNode.Pattern, TypeNode),
-						aRegId,
-						out aError
-					);
-				} else {
-					return aDefConstructor.MapMatch(MatchNode, aRegId, out aError);
+					aDefConstructor.CreateTempReg(out var ResultReg);
+					aDefConstructor.Commands.Push(mIL_AST.Alias(PatternNode.Pos, ResultReg, aRegId));
+					var ResultType = TypeAnnotation.AssertNotEmpty();
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, ResultType);
+					return mResult.OK((ResultReg, ResultType)).WithErrorType<(tPos Pos, tText Error)>();
 				}
-			}
-			default: {
-				throw mError.Error(
-					$"not implemented: {nameof(mSPO_AST)}.{PatternNode.GetType().Name} in {nameof(mSPO2IL)}.{nameof(MapMatch)}(...)"
-				);
+				case mSPO_AST.tMatchTupleNode<tPos> { Items: var Items, TypeAnnotation: var TypeAnnotation }: {
+					var RemainingReg = aRegId;
+					mAssert.AreEquals(Items.Take(2).ToArrayList().Size, 2u);
+					foreach (var Item in Items.Reverse()) {
+						aDefConstructor.CreateTempReg(out var ItemReg);
+						aDefConstructor.Commands.Push(
+							mIL_AST.GetSecond(PatternNode.Pos, ItemReg, RemainingReg)
+						);
+						aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ItemReg, Item.TypeAnnotation.AssertNotEmpty());
+						if (!aDefConstructor.MapMatch(Item, ItemReg).Match(out var _, out var Error)) {
+							return mResult.Fail(Error);
+						}
+						aDefConstructor.CreateTempReg(out var NewRestReg);
+						aDefConstructor.Commands.Push(
+							mIL_AST.GetFirst(PatternNode.Pos, NewRestReg, RemainingReg)
+						);
+						RemainingReg = NewRestReg;
+					}
+					aDefConstructor.CreateTempReg(out var ResultReg);
+					aDefConstructor.Commands.Push(mIL_AST.Alias(PatternNode.Pos, ResultReg, aRegId));
+					var ResultType = TypeAnnotation.AssertNotEmpty();
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, ResultType);
+					return mResult.OK((ResultReg, ResultType)).WithErrorType<(tPos Pos, tText Error)>();
+				}
+				case mSPO_AST.tMatchPairNode<tPos> { Tail: var Tail, Head: var Head, Pos: var Pos }: {
+					aDefConstructor.CreateTempReg(out var PairReg);
+					aDefConstructor.Commands.Push(mIL_AST.TryAsPair(Pos, PairReg, aRegId));
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(PairReg, PatternNode.TypeAnnotation.AssertNotEmpty());
+					aDefConstructor.CreateTempReg(out var HeadReg);
+					aDefConstructor.Commands.Push(mIL_AST.GetSecond(Pos, HeadReg, PairReg));
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(HeadReg, Head.TypeAnnotation.AssertNotEmpty());
+					if (!aDefConstructor.MapMatch(Head, HeadReg).Match(out var HeadMatch, out var Error)) {
+						return mResult.Fail(Error);
+					}
+					aDefConstructor.CreateTempReg(out var TailReg);
+					aDefConstructor.Commands.Push(mIL_AST.GetFirst(Pos, TailReg, PairReg));
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(TailReg, Tail.TypeAnnotation.AssertNotEmpty());
+					if (!aDefConstructor.MapMatch(Tail, TailReg).Match(out var TailMatch, out Error)) {
+						return mResult.Fail(Error);
+					}
+					aDefConstructor.CreateTempReg(out var ResultReg);
+					aDefConstructor.Commands.Push(
+						mIL_AST.CreatePair(Pos, ResultReg, TailMatch.Reg, HeadMatch.Reg)
+					);
+					var ResultType = mVM_Type.Pair(TailMatch.Type, HeadMatch.Type);
+					aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(ResultReg, ResultType);
+					return mResult.OK((ResultReg, ResultType)).WithErrorType<(tPos Pos, tText Error)>();
+				}
+				case mSPO_AST.tMatchGuardNode<tPos> { Match: var Match, Guard: var Guard }: {
+					return aDefConstructor.MapMatch(Match, aRegId);
+				}
+				case mSPO_AST.tMatchNode<tPos> MatchNode: {
+					if (TypeNode.IsSome(out var TypeNode_)) {
+						if (MatchNode.TypeExpression.IsSome(out var MatchTypeNode)) {
+							throw mError.Error("not implemented");
+						}
+
+						return aDefConstructor.MapMatch(
+							mSPO_AST.Match(aMatchNode.Pos, MatchNode.Pattern, TypeNode),
+							aRegId
+						);
+					} else {
+						return aDefConstructor.MapMatch(MatchNode, aRegId);
+					}
+				}
+				default: {
+					throw mError.Error(
+						$"not implemented: {nameof(mSPO_AST)}.{PatternNode.GetType().Name} in {nameof(mSPO2IL)}.{nameof(MapMatch)}(...)"
+					);
+				}
 			}
 		}
-		
-		aError = default;
-		return true;
-	}
 	
 	public static tBool
 	MapDef<tPos>(
@@ -1558,7 +1581,7 @@ mSPO2IL {
 		out (tPos Pos, tText ErrorText) aError
 	) => (
 		aDefConstructor.MapExpression(aModuleConstructor, aDefNode.Src).Match(out var ValueReg, out aError) &&
-		aDefConstructor.MapMatch(aDefNode.Des, ValueReg, out aError)
+		aDefConstructor.MapMatch(aDefNode.Des, ValueReg).Match(out var _, out aError)
 	);
 	
 	public static tBool
@@ -1820,7 +1843,7 @@ mSPO2IL {
 				]
 			);
 			if (Call.Result.IsSome(out var Result_)) {
-				if (!aDefConstructor.MapMatch(Result_, Result, out aError)) {
+				if (!aDefConstructor.MapMatch(Result_, Result).Match(out var _, out aError)) {
 					return false;
 				}
 			}


### PR DESCRIPTION
## Summary
- convert MapMatch to return a typed mResult instead of a boolean/out parameter
- rebuild pair matches into new registers and alias other patterns so MapMatch always yields an immutable result register
- update callers to use the new MapMatch signature and propagate typed match results

## Testing
- not run (missing required .NET 9 runtime in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd9b257dcc8329aa922f478ad7a778