### PR TITLE
Bind generic placeholders to type vars during IL generation

### DIFF
--- a/SPO_CS/Doc/GenericTypeGeneration.md
+++ b/SPO_CS/Doc/GenericTypeGeneration.md
@@ -1,0 +1,29 @@
+# Generic Type Generation Notes
+
+## Problem statement
+- The regression fixture `07_12_GenericTypes.ILT` shows that the generated IL type table for generic helpers still contains standalone `[§FREE]` entries instead of binding the placeholder to the generic head that introduces it.【F:SPO_CS/Regression.Tests/07_12_GenericTypes.ILT†L2-L26】
+- These free placeholders are emitted because the current lowering pipeline maps the universal quantifier head just like any other free type, so the resulting definitions never record how occurrences inside the body relate back to the binder.
+- Downstream consumers like `mIL_GenerateOpcodes` therefore materialise VM types where the `Generic` wrapper keeps pointing at an unconstrained free slot, which is dropped when the procedure type is normalised.【F:SPO_CS/src/mIL_GenerateOpcodes.cs†L96-L136】
+
+## Root cause in the pipeline
+- `tModuleConstructor.MapType` simply recurses through the VM type graph. In the `Generic` branch it first calls itself on the head type, which is still a raw `Free`, so it creates a fresh `[§FREE]` definition and reuses that id for the entire body.【F:SPO_CS/src/mSPO2IL.cs†L202-L272】
+- When the AST contains explicit generic type nodes we also emit `TypeFree` followed by `TypeGeneric`, but we never record the head symbol in the constructor's `TypeDict`. That means subsequent lookups of the parameter inside the body cannot resolve to a bound `TypeVar` instance either.【F:SPO_CS/src/mSPO2IL.cs†L1030-L1042】
+- Finally, `CreateDefType` just wraps the annotated procedure type without inspecting whether the result is a `Generic`. No environment state is threaded that would allow us to map type ids from the lambda scope back to the enclosing module.【F:SPO_CS/src/mSPO2IL.cs†L309-L320】
+
+## Implementation sketch
+1. **Track generic binders during type lowering.**
+   - Extend `MapType` with a lightweight “generic scope” (e.g. a `Dictionary<tNat64, tText>` keyed by the bound type's `DebugId`). Whenever we enter the `Generic` case we should:
+     1. Allocate a dedicated type id for the binder (still emitted via `TypeFree` so the VM can allocate a placeholder),
+     2. Register that mapping in the scope, and
+     3. Recurse into the body while passing the updated scope.
+   - When we later encounter a `Free` node whose representative is present in that scope, emit a `TypeVar` definition that aliases the previously created binder id instead of another `[§FREE]` entry. This keeps all uses of the parameter tied to the quantifier rather than floating independently.
+2. **Expose binder information while compiling generic lambdas.**
+   - When visiting `tGenericTypeNode` in `MapExpression`, add the freshly created binder id (and its `mVM_Type.Var` representation) to the def constructor's `TypeDict` so nested lookups can resolve it to the right VM type during environment construction.【F:SPO_CS/src/mSPO2IL.cs†L1030-L1042】
+   - If the type body introduces additional type expressions, ensure those recursively respect the scope described in step 1, so the same binder id is threaded through nested `TypeGenericApply` nodes.
+3. **Normalise definition signatures.**
+   - Update `CreateDefType` (and the `FinishMapProc` call sites) to detect when the lambda's annotation is `Generic`. Split it into `(binder, innerProcType)` and return a `Proc` whose result is the generic wrapper plus explicit metadata about the binder id. That metadata can be reused when instantiating closures so that calls like `InitProc` have access to the quantifier during environment lowering.【F:SPO_CS/src/mSPO2IL.cs†L309-L320】
+   - When the enclosing module writes the final type table (`EnsureTypeDefinition`), inject the `TypeVar` entry for each binder before emitting the `TypeGeneric` node so readers observe a stable sequence of `(binder placeholder → var alias → generic wrapper)`.
+4. **Regression protection.**
+   - Once the binding logic is in place, adjust the `07_12_GenericTypes.ILT` expectation so the def types reference `[§VAR …]` entries instead of loose `[§FREE]` placeholders. Add an additional regression that instantiates the same generic twice in one module to verify that the scope map prevents duplicate binder ids.
+
+This staged approach keeps the existing recursion support untouched while introducing a clear flow for generic placeholders: the scope map guarantees structural sharing during type lowering, and the augmented def constructor state lets us thread those bindings all the way to the emitted IL.

--- a/SPO_CS/src/mSPO2IL.cs
+++ b/SPO_CS/src/mSPO2IL.cs
@@ -24,6 +24,13 @@ mSPO2IL {
 		internal mStd.tFunc<tPos, tPos, tPos> MergePos;
 	}
 	
+	private sealed class
+	tGenericBinder {
+		public mVM_Type.tType HeadType = default!;
+		public tText HeadTypeId = default!;
+		public tText? VarTypeId;
+	}
+	
 	public struct
 	tDefConstructor<tPos> {
 		// TODO: add SubDefs
@@ -168,8 +175,11 @@ mSPO2IL {
 	public static tText
 	MapType<tPos>(
 		this tModuleConstructor<tPos> aModuleConstructor,
-		mVM_Type.tType aType
+		mVM_Type.tType aType,
+		System.Collections.Generic.Dictionary<tNat64, tGenericBinder>? aGenericScope = null
 	) {
+		aGenericScope ??= new System.Collections.Generic.Dictionary<tNat64, tGenericBinder>();
+
 		switch (aType) {
 			case var a when a.IsType(): {
 				aModuleConstructor.Types = aModuleConstructor.Types.Set(mIL_GenerateOpcodes.cTypeType, a);
@@ -192,22 +202,42 @@ mSPO2IL {
 				return mIL_GenerateOpcodes.cAnyType;
 			}
 			case var a when a.IsFree(out var Id_, out var Ref): {
+				if (
+					aGenericScope.TryGetValue(a.DebugId, out var Binder) ||
+					aGenericScope.TryGetValue(Ref.DebugId, out Binder)
+				) {
+					var VarId = Binder.VarTypeId;
+					if (VarId is null) {
+						VarId = "[§VAR {Binder.HeadTypeId}]";
+						var VarType = mVM_Type.Var(Binder.HeadType);
+						aModuleConstructor.EnsureTypeDefinition(
+							VarId,
+							VarType,
+							() => mIL_AST.TypeVar(default(tPos), VarId, Binder.HeadTypeId)
+						);
+						Binder.VarTypeId = VarId;
+					}
+					return VarId;
+				}
+
+
+
 				if (Ref.Kind is mVM_Type.tKind.Free) {
 					aModuleConstructor.EnsureTypeDefinition(Id_, a, () => mIL_AST.TypeFree(default(tPos), Id_));
 					return Id_;
 				} else {
-					return aModuleConstructor.MapType(Ref);
+					return aModuleConstructor.MapType(Ref, aGenericScope);
 				}
 			}
 			case var a when a.IsPrefix(out var Prefix, out var Type): {
-				var Id = aModuleConstructor.MapType(Type);
+				var Id = aModuleConstructor.MapType(Type, aGenericScope);
 				var NewId = $"[#{Prefix}:{Id}]";
 				aModuleConstructor.EnsureTypeDefinition(NewId, a, () => mIL_AST.TypePrefix(default(tPos), NewId, Prefix, Id));
 				return NewId;
 			}
 			case var a when a.IsPair(out var Type1, out var Type2): {
-				var Id1 = aModuleConstructor.MapType(Type1);
-				var Id2 = aModuleConstructor.MapType(Type2);
+				var Id1 = aModuleConstructor.MapType(Type1, aGenericScope);
+				var Id2 = aModuleConstructor.MapType(Type2, aGenericScope);
 				var NewId = $"[{Id1};{Id2}]";
 				aModuleConstructor.EnsureTypeDefinition(NewId, a, () => mIL_AST.TypePair(default(tPos), NewId, Id1, Id2));
 				return NewId;
@@ -215,7 +245,7 @@ mSPO2IL {
 			case var a when a.IsRecord(out var Fields): {
 				var RecTypeId = mIL_AST.cEmptyType;
 				foreach (var Field in Fields.ToStream()) {
-					var FieldTypeId = aModuleConstructor.MapType(Field.Value);
+					var FieldTypeId = aModuleConstructor.MapType(Field.Value, aGenericScope);
 					var PrefixedFieldTypeId = $"[#{Field.Key} {FieldTypeId}]";
 					aModuleConstructor.TypeDef.Push(mIL_AST.TypePrefix(default(tPos), PrefixedFieldTypeId, Field.Key.ToString(), FieldTypeId)); // TODO: remove .ToString() ???
 					var NewRecTypeId = $"[{RecTypeId}, {PrefixedFieldTypeId}]";
@@ -226,48 +256,75 @@ mSPO2IL {
 				return RecTypeId;
 			}
 			case var a when a.IsSet(out var Type1, out var Type2): {
-				var Id1 = aModuleConstructor.MapType(Type1);
-				var Id2 = aModuleConstructor.MapType(Type2);
+				var Id1 = aModuleConstructor.MapType(Type1, aGenericScope);
+				var Id2 = aModuleConstructor.MapType(Type2, aGenericScope);
 				var NewId = $"[{Id1}|{Id2}]";
 				aModuleConstructor.EnsureTypeDefinition(NewId, a, () => mIL_AST.TypeSet(default(tPos), NewId, Id1, Id2));
 				return NewId;
 			}
 			case var a when a.IsProc(out var EnvType, out var ArgType, out var ResType): {
-				var IdArg = aModuleConstructor.MapType(ArgType);
-				var IdRes = aModuleConstructor.MapType(ResType);
+				var IdArg = aModuleConstructor.MapType(ArgType, aGenericScope);
+				var IdRes = aModuleConstructor.MapType(ResType, aGenericScope);
 				var IdFunc = $"[{IdArg}->{IdRes}]";
 				var FuncType = mVM_Type.Proc(mVM_Type.Empty(), ArgType, ResType);
-				aModuleConstructor.EnsureTypeDefinition(IdFunc, FuncType, () => mIL_AST.TypeFunc(default(tPos), IdFunc, IdArg, IdRes));
-				
+				aModuleConstructor.EnsureTypeDefinition(IdFunc, FuncType, () => mIL_AST.TypeFunc(default(tPos),IdFunc, IdArg, IdRes));
+
 				if (EnvType.IsEmpty()) {
 					return IdFunc;
 				}
-				
-				var IdEnv = aModuleConstructor.MapType(EnvType);
+
+				var IdEnv = aModuleConstructor.MapType(EnvType, aGenericScope);
 				var IdEnvFunc = $"[{IdEnv}:{IdFunc}]";
 				aModuleConstructor.EnsureTypeDefinition(IdEnvFunc, a, () => mIL_AST.TypeMethod(default(tPos), IdEnvFunc, IdEnv, IdFunc));
 				return IdEnvFunc;
 			}
 			case var a when a.IsVar(out var InnerType): {
-				var InnerId = aModuleConstructor.MapType(InnerType);
+				var InnerId = aModuleConstructor.MapType(InnerType, aGenericScope);
 				var NewId = $"[§VAR {InnerId}]";
-				
+
 				aModuleConstructor.EnsureTypeDefinition(NewId, a, () => mIL_AST.TypeVar(default(tPos), NewId, InnerId));
-				
+
 				return NewId;
 			}
 			case var a when a.IsRecursive(out var HeadType, out var BodyType): {
-				var HeadId = aModuleConstructor.MapType(HeadType);
-				var BodyId = aModuleConstructor.MapType(BodyType);
+				var HeadId = aModuleConstructor.MapType(HeadType, aGenericScope);
+				var BodyId = aModuleConstructor.MapType(BodyType, aGenericScope);
 				var NewId = $"[§REC {HeadId} => {BodyId}]";
 				aModuleConstructor.EnsureTypeDefinition(NewId, a, () => mIL_AST.TypeRecursive(default(tPos), NewId, HeadId, BodyId));
 				return NewId;
 			}
 			case var a when a.IsGeneric(out var HeadType, out var BodyType): {
-				var HeadId = aModuleConstructor.MapType(HeadType);
-				var BodyId = aModuleConstructor.MapType(BodyType);
-				var NewId = $"[$ALL {HeadId} => {BodyId}]";
-				aModuleConstructor.EnsureTypeDefinition(NewId, a, () => mIL_AST.TypeGeneric(default(tPos), NewId, HeadId, BodyId));
+				var HeadId = aModuleConstructor.MapType(HeadType, aGenericScope);
+				var Binder = new tGenericBinder {
+					HeadType = HeadType,
+					HeadTypeId = HeadId,
+				};
+				var HeadKey = HeadType.DebugId;
+				tGenericBinder? PreviousBinder = default;
+				var HasPrevious = aGenericScope.TryGetValue(HeadKey, out PreviousBinder);
+				aGenericScope[HeadKey] = Binder;
+				var CanonicalKey = HeadType.Refs.Length > 0 ? HeadType.Refs[0].DebugId : HeadKey;
+				tGenericBinder? PreviousCanonical = default;
+				var HasCanonical = CanonicalKey != HeadKey && aGenericScope.TryGetValue(CanonicalKey, out PreviousCanonical);
+				if (CanonicalKey != HeadKey) {
+					aGenericScope[CanonicalKey] = Binder;
+				}
+				var BodyId = aModuleConstructor.MapType(BodyType, aGenericScope);
+				if (HasPrevious) {
+					aGenericScope[HeadKey] = PreviousBinder!;
+				} else {
+					aGenericScope.Remove(HeadKey);
+				}
+				if (CanonicalKey != HeadKey) {
+					if (HasCanonical) {
+						aGenericScope[CanonicalKey] = PreviousCanonical!;
+					} else {
+						aGenericScope.Remove(CanonicalKey);
+					}
+				}
+				var HeadBinderId = Binder.VarTypeId ?? HeadId;
+				var NewId = $"[$ALL {HeadBinderId} => {BodyId}]";
+				aModuleConstructor.EnsureTypeDefinition(NewId, a, () => mIL_AST.TypeGeneric(default(tPos), NewId, HeadBinderId, BodyId));
 				return NewId;
 			}
 			default: {
@@ -275,7 +332,6 @@ mSPO2IL {
 			}
 		}
 	}
-
 	public static mResult.tResult<mVM_Type.tType, tText>
 	CreateEnvType<tPos>(
 		this ref tDefConstructor<tPos> aDefConstructor,
@@ -1031,10 +1087,16 @@ mSPO2IL {
 				aDefConstructor.Commands.Push(
 					mIL_AST.TypeFree(HeadType.Pos, HeadType.Id)
 				);
-				
+
+				var PreviousTypeDict = aDefConstructor.TypeDict;
+				var BinderType = mVM_Type.Var(mVM_Type.Free(HeadType.Id));
+				aDefConstructor.TypeDict = aDefConstructor.TypeDict.Set(HeadType.Id, BinderType);
+
 				if (!aDefConstructor.MapExpression(aModuleConstructor, BodyType).Match(out var BodyTypeReg, out var Error)) {
+					aDefConstructor.TypeDict = PreviousTypeDict;
 					return mResult.Fail(Error);
 				}
+				aDefConstructor.TypeDict = PreviousTypeDict;
 				aDefConstructor.Commands.Push(
 					mIL_AST.TypeGeneric(Pos, aDefConstructor.CreateTempReg(out var ResultReg), HeadType.Id, BodyTypeReg)
 				);


### PR DESCRIPTION
## Summary
- add a lightweight binder scope to `MapType` so generic placeholders reuse a shared type var definition
- teach the generic type expression lowering to seed the binder in the current type dictionary before mapping the body

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68efe0a02c788329ad51b1ab75d00bdf