### PR TITLE
Add type function kind for generics

### DIFF
--- a/SPO_CS/src/mIL_GenerateOpcodes.cs
+++ b/SPO_CS/src/mIL_GenerateOpcodes.cs
@@ -531,7 +531,7 @@ mIL_GenerateOpcodes {
 						var ArgType = Types.Get(ArgReg);
 						
 						var (SuccessType, FailureType) = ArgType.SplitBy(
-							_ => _.IsType()
+							_ => _.IsType() || _.IsTypeFunc()
 						);
 						
 						mAssert.IsTrue(
@@ -776,7 +776,7 @@ mIL_GenerateOpcodes {
 						var FreeTypeReg = Regs.GetOrThrow(RegId2, Command);
 						var TypeBodyReg = Regs.GetOrThrow(RegId3, Command);
 						Regs = Regs.Set(RegId1, NewProc.TypeGeneric(Span, FreeTypeReg, TypeBodyReg));
-						Types.Push(mVM_Type.Type());
+                                                Types.Push(mVM_Type.TypeFunc());
 						break;
 					}
 					default: {

--- a/SPO_CS/src/mSPO_AST_Types.cs
+++ b/SPO_CS/src/mSPO_AST_Types.cs
@@ -155,7 +155,7 @@ mSPO_AST_Types {
 				() => {
 					if (Lambda.Generic.IsSome(out var GenericPattern)) {
 						// TODO: AI generated code has to be reviewed
-						return UpdatePatternTypes(GenericPattern, mVM_Type.Type(), tTypeRelation.Equal, aScope).ThenTry(
+                                               return UpdatePatternTypes(GenericPattern, mVM_Type.TypeFunc(), tTypeRelation.Equal, aScope).ThenTry(
 							aGenTypeScope => UpdatePatternTypes(
 								Lambda.Head,
 								mStd.cEmpty,
@@ -168,7 +168,7 @@ mSPO_AST_Types {
 									aResTypeScope => {
 										var Proc = mVM_Type.Proc(mVM_Type.Empty(), aArgTypeScope.Type, aResTypeScope);
 										
-										if (aGenTypeScope.Type.IsType()) {
+if (aGenTypeScope.Type.IsType() || aGenTypeScope.Type.IsTypeFunc()) {
 											var T = aGenTypeScope.Scope.Where(
 												_ => _.Id == GenericPattern.TryGetId().AssertNotEmpty()
 											).TryFirst(
@@ -377,31 +377,36 @@ mSPO_AST_Types {
 				break;
 			}
 			case mSPO_AST.tFreeIdPatternNode<tPos> FreePatternId: {
-				Result = aType.Then(
-					a => (
-						a.IsType()
-						? (
+			Result = aType.Then(
+				a => {
+					if (a.IsType() || a.IsTypeFunc()) {
+						var FreeType = mVM_Type.Free(FreePatternId.Id);
+
+						return (
 							a,
 							mStream.Stream(
 								ScopeItem(
 									FreePatternId.Id,
 									a,
-									mVM_Type.Free(FreePatternId.Id)
+									mMaybe.Some(FreeType)
 								),
 								aScope
 							)
+						);
+					}
+
+					return (
+						a,
+						mStream.Stream(
+							ScopeItem(
+								FreePatternId.Id,
+								a
+							),
+							aScope
 						)
-						: (
-							a,
-							mStream.Stream(
-								ScopeItem(
-									FreePatternId.Id,
-									a
-								),
-								aScope
-							)
-						)
-					)
+					);
+				}
+			)
 				).ElseFail(
 					() => (FreePatternId.Pos, $"missing type for '{FreePatternId.Id}'")
 				);
@@ -686,7 +691,7 @@ mSPO_AST_Types {
 				foreach (var Item in RecLambdas.List) {
 					var HeadScope = NewScope;
 					if (Item.Lambda.Generic.IsSome(out var GenericPattern)) {
-						if (!UpdatePatternTypes(GenericPattern, mVM_Type.Type(), tTypeRelation.Equal, HeadScope).Match(out var GenScope, out var GenError)) {
+                                                if (!UpdatePatternTypes(GenericPattern, mVM_Type.TypeFunc(), tTypeRelation.Equal, HeadScope).Match(out var GenScope, out var GenError)) {
 							return mResult.Fail(GenError);
 						}
 						HeadScope = GenScope.Scope;
@@ -860,7 +865,8 @@ mSPO_AST_Types {
 				).ElseFail(
 					() => (IdNode.Pos, $"unknown type of Identifier '{IdNode.Id}'")
 				).ThenTry(
-					_ => _.Type.IsType()
+					_
+					=> (_.Type.IsType() || _.Type.IsTypeFunc())
 					? _.FreeType.ElseFail(() => (IdNode.Pos, "impossible ???"))
 					: _.Type
 				);

--- a/SPO_CS/src/mVM_Type.cs
+++ b/SPO_CS/src/mVM_Type.cs
@@ -264,16 +264,35 @@ mVM_Type {
 		)
 	);
 	
-	public static tType
-	Type(
-	) => new() {
-		Kind = tKind.Type,
-	};
-	
-	public static tBool
-	IsType(
-		this tType aType
-	) => aType.Kind is tKind.Type;
+        public static tType
+        Type(
+        ) => new() {
+                Kind = tKind.Type,
+        };
+
+        public static tType
+        TypeFunc(
+        ) => Proc(
+                Empty(),
+                Type(),
+                Type()
+        );
+
+        public static tBool
+        IsType(
+                this tType aType
+        ) => aType.Kind is tKind.Type;
+
+        public static tBool
+        IsTypeFunc(
+                this tType aType
+        ) {
+                if (!aType.IsProc(out var ObjType, out var ArgType, out var ResType)) {
+                        return false;
+                }
+
+                return ObjType.IsEmpty() && ArgType.IsType() && ResType.IsType();
+        }
 	
 	public static tType
 	Value(


### PR DESCRIPTION
## Summary
- add a dedicated `§TYPE => §TYPE` kind via `TypeFunc`/`IsTypeFunc`
- expect generic patterns to bind type functions and propagate kind checks
- emit type-function metadata for IL type generics and `TRY_AS_TYPE`

## Testing
- dotnet run --project SPO_CS.csproj -- --list *(fails: dotnet command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_690cc9d43a548329ad6c6e5bda69f03c